### PR TITLE
Add option to show file name in preview

### DIFF
--- a/src/DropzoneArea.js
+++ b/src/DropzoneArea.js
@@ -179,6 +179,7 @@ class DropzoneArea extends Component{
                         <PreviewList 
                             fileObjects={this.state.fileObjects} 
                             handleRemove={this.handleRemove.bind(this)}
+                            showFileNames={this.props.showFileNamesInPreview}
                         />
                     }
                 </Dropzone>
@@ -190,6 +191,7 @@ class DropzoneArea extends Component{
                         <PreviewList 
                             fileObjects={this.state.fileObjects} 
                             handleRemove={this.handleRemove.bind(this)}
+                            showFileNames={this.props.showFileNamesInPreview}
                         />
                     </Fragment>
                 }
@@ -222,6 +224,7 @@ DropzoneArea.defaultProps = {
     dropzoneText: 'Drag and drop an image file here or click',
     showPreviews: false, // By default previews show up under in the dialog and inside in the standalone
     showPreviewsInDropzone: true,
+    showFileNamesInPreview: false,
     showAlerts: true,
     clearOnUnmount: true,
     onChange: () => {},
@@ -236,6 +239,7 @@ DropzoneArea.propTypes = {
     dropzoneText: PropTypes.string,
     showPreviews: PropTypes.bool,
     showPreviewsInDropzone: PropTypes.bool,
+    showFileNamesInPreview: PropTypes.bool,
     showAlerts: PropTypes.bool,
     clearOnUnmount: PropTypes.bool, 
     onChange: PropTypes.func,

--- a/src/PreviewList.js
+++ b/src/PreviewList.js
@@ -44,7 +44,7 @@ const styles = {
 }
 
 function PreviewList(props){
-    const {fileObjects, handleRemove, classes} = props
+    const {fileObjects, handleRemove, showFileNames, classes} = props;
     return(
         <Grid container spacing={8}>
             {
@@ -58,6 +58,10 @@ function PreviewList(props){
                         <Grid item xs={4} key={i} className={classes.imageContainer}>
                             {img}
                             
+                            {showFileNames &&
+                                <p>{fileObject.file.name}</p>
+                            }
+
                             <Fab onClick={handleRemove(i)}
                                 aria-label="Delete" 
                                 className={classes.removeBtn}>


### PR DESCRIPTION
It can be difficult to discern between non-image files due to the generic preview image used for these files (1st screenshot). This PR adds an option to show the file name beneath the preview image (2nd and 3rd screenshots). Note that the option defaults to false to maintain consistent functionality with previous versions.

![screen shot 2019-02-02 at 1 29 01 am](https://user-images.githubusercontent.com/8296030/52162532-115a8c80-268a-11e9-9cec-da3d68ad4e18.png)

<img width="695" alt="screen shot 2019-02-01 at 7 17 34 pm" src="https://user-images.githubusercontent.com/8296030/52159406-0cc9b000-2659-11e9-8f73-2906bdac16ca.png">
<img width="686" alt="screen shot 2019-02-01 at 7 18 00 pm" src="https://user-images.githubusercontent.com/8296030/52159407-0d624680-2659-11e9-8b9e-2ef0eef82ec1.png">
