### PR TITLE
added showFileNames to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ export default DropzoneAreaExample;
 | showAlerts    | Boolean | true             | shows styled snackbar alerts when files are dropped, deleted or rejected. 
 | dropzoneParagraphClass    | String | null             | Custom CSS class name for text inside the container. 
 | showFileNamesInPreview | Boolean | false | Shows file name under the image    
-
+| showFileNames | Boolean | false | Shows file name under the dropzone image.
 
 ### DropzoneArea Component Events
 


### PR DESCRIPTION
I added the showFileNames property to the list of DropzoneArea Component Properties. I spent more time than I'd like to admit trying to figure out why showFileNamesInPreview wasn't working... Hopefully this helps others in the future.