### PR TITLE
User dropzoneClass should take precedence

### DIFF
--- a/src/DropzoneArea.js
+++ b/src/DropzoneArea.js
@@ -190,7 +190,7 @@ class DropzoneArea extends Component {
                     accept={this.props.acceptedFiles.join(',')}
                     onDrop={this.onDrop.bind(this)}
                     onDropRejected={this.handleDropRejected.bind(this)}
-                    className={classNames(classes.dropZone, this.props.dropzoneClass)}
+                    className={classNames(this.props.dropzoneClass, classes.dropZone)}
                     acceptClassName={classes.stripes}
                     rejectClassName={classes.rejectStripes}
                     maxSize={this.props.maxFileSize}


### PR DESCRIPTION
currently anything overridden in user dropzoneClass that is also in the coded dropzoneclass does not apply e.g. min-height