### PR TITLE
Remove material-ui deprecated theme.spacing.unit

### DIFF
--- a/src/SnackbarContentWrapper.js
+++ b/src/SnackbarContentWrapper.js
@@ -39,7 +39,7 @@ const styles = theme => ({
   },
   iconVariant: {
     opacity: 0.9,
-    marginRight: theme.spacing.unit,
+    marginRight: theme.spacing(1),
   },
   message: {
     display: 'flex',


### PR DESCRIPTION
this is to remove the warning:
Warning: Material-UI: theme.spacing.unit usage has been deprecated.
It will be removed in v5.
You can replace `theme.spacing.unit * y` with `theme.spacing(y)`.

theme.spacing.unit is deprecated and will be removed around January 2020