### PR TITLE
Allow initialFiles prop when using typescript

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -12,6 +12,7 @@ export interface DropzoneAreaProps {
     clearOnUnmount?: boolean;
     dropzoneClass?: string;
     dropzoneParagraphClass?: string;
+    initialFiles?: string[];
     onChange?: (files: any) => void;
     onDrop?: (files: any) => void;
     onDropRejected?: (files: any, evt: any) => void;


### PR DESCRIPTION
After some fumbling around I figured out that my editor was complaining about the `initialProps` not being there because the typescript definition file was not updated with it. Hope this helps.