### PR TITLE
Update types in the dist folder for npm

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,40 +1,54 @@
-import * as React from "react";
+import * as React from 'react';
 
 export interface DropzoneAreaProps {
-    acceptedFiles?: string[];
-    filesLimit?: number;
-    maxFileSize?: number;
-    dropzoneText?: string;
-    showPreviews?: boolean;
-    showPreviewsInDropzone?: boolean;
-    showFileNamesInPreview?: boolean;
-    showAlerts?: boolean;
-    clearOnUnmount?: boolean;
-    dropzoneClass?: string;
-    dropzoneParagraphClass?: string;
-    initialFiles?: string[];
-    onChange?: (files: any) => void;
-    onDrop?: (files: any) => void;
-    onDropRejected?: (files: any, evt: any) => void;
-    onDelete?: (file: any) => void;
+  acceptedFiles?: string[];
+  filesLimit?: number;
+  maxFileSize?: number;
+  dropzoneText?: string;
+  showPreviews?: boolean;
+  showPreviewsInDropzone?: boolean;
+  showFileNamesInPreview?: boolean;
+  showFileNames?: boolean;
+  showAlerts?: boolean;
+  clearOnUnmount?: boolean;
+  dropzoneClass?: string;
+  dropzoneParagraphClass?: string;
+  initialFiles?: string[];
+  onChange?: (files: any) => void;
+  onDrop?: (files: any) => void;
+  onDropRejected?: (files: any, evt: any) => void;
+  onDelete?: (file: any) => void;
+  getFileLimitExceedMessage?: (filesLimit: number) => string;
+  getFileAddedMessage?: (fileName: string) => string;
+  getFileRemovedMessage?: (fileName: string) => string;
+  getDropRejectMessage?: (
+    rejectedFile: { name: string; type: string | undefined; size: number },
+    acceptedFiles: string[],
+    maxFileSize: number
+  ) => string;
 }
 export const DropzoneArea: React.ComponentType<DropzoneAreaProps>;
 
 export interface DropzoneDialogProps {
-    open: boolean
-    onSave?: (files: any) => void;
-    onDelete?: (file: any) => void;
-    onClose?: () => void;
-    onChange?: (files: any) => void;
-    onDrop?: (files: any) => void;
-    onDropRejected?: (files: any, evt: any) => void;
-    acceptedFiles?: string[];
-    filesLimit?: number;
-    maxFileSize?: number;
-    dropzoneText?: string;
-    showPreviews?: boolean;
-    showPreviewsInDropzone?: boolean;
-    showAlerts?: boolean;
-    clearOnUnmount?: boolean;
+  open: boolean;
+  onSave?: (files: any) => void;
+  onDelete?: (file: any) => void;
+  onClose?: () => void;
+  onChange?: (files: any) => void;
+  onDrop?: (files: any) => void;
+  onDropRejected?: (files: any, evt: any) => void;
+  acceptedFiles?: string[];
+  filesLimit?: number;
+  maxFileSize?: number;
+  dropzoneText?: string;
+  showPreviews?: boolean;
+  showPreviewsInDropzone?: boolean;
+  showAlerts?: boolean;
+  clearOnUnmount?: boolean;
+  dialogTitle?: string;
+  cancelButtonText?: string;
+  submitButtonText?: string;
+  maxWidth?: string;
+  fullWidth?: boolean;
 }
 export const DropzoneDialog: React.ComponentType<DropzoneDialogProps>;


### PR DESCRIPTION
I was waiting for the recent PR to update the typescript type definitions, but I noticed that they weren't actually updated in the dist folder.

The new types aren't available via the npm distribution because of this.

This is simply copying the updated types into the correct folder so they can actually be used.