### PR TITLE
Add dialogProps prop to customize DropzoneDialog appearance.

### DIFF
--- a/src/DropzoneDialog.js
+++ b/src/DropzoneDialog.js
@@ -96,6 +96,7 @@ class DropzoneDialog extends React.Component {
                     onClose={this.handleClose.bind(this)}
                     maxWidth={this.props.maxWidth}
                     fullWidth={this.props.fullWidth}
+                    {...this.props.dialogProps}
                 >
                     <DialogTitle>{this.props.dialogTitle}</DialogTitle>
                     <DialogContent>
@@ -150,6 +151,7 @@ DropzoneDialog.defaultProps = {
     showAlerts: true,
     clearOnUnmount: true,
     dialogTitle: "Upload file",
+    dialogProps: {},
     submitButtonText: "Submit",
     cancelButtonText: "Cancel",
     maxWidth: "sm",
@@ -182,6 +184,7 @@ DropzoneDialog.propTypes = {
     showAlerts: PropTypes.bool,
     clearOnUnmount: PropTypes.bool,
     dialogTitle: PropTypes.string,
+    dialogProps: PropTypes.object,
     submitButtonText: PropTypes.string,
     cancelButtonText: PropTypes.string,
     maxWidth: PropTypes.string,

--- a/src/DropzoneDialog.js
+++ b/src/DropzoneDialog.js
@@ -92,11 +92,11 @@ class DropzoneDialog extends React.Component {
         return (
             <Fragment>
                 <Dialog
+                    {...this.props.dialogProps}
                     open={this.state.open}
                     onClose={this.handleClose.bind(this)}
                     maxWidth={this.props.maxWidth}
                     fullWidth={this.props.fullWidth}
-                    {...this.props.dialogProps}
                 >
                     <DialogTitle>{this.props.dialogTitle}</DialogTitle>
                     <DialogContent>


### PR DESCRIPTION
dialogProps is an object to allow customize classNames and allow draggable pattern like so:

[https://material-ui.com/components/dialogs/#draggable-dialog](url)