### PR TITLE
Add more customization props

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -51,7 +51,7 @@
     "jsx-quotes": ["error", "prefer-double"],
     "key-spacing": "error",
     "keyword-spacing": "error",
-    "max-len": ["error", 120, 4],
+    "max-len": ["error", 120, 4, {"ignoreComments": true}],
     "new-cap": ["off", {"capIsNew": true, "newIsCap": true}],
     "no-await-in-loop": "error",
     "no-case-declarations": "off",

--- a/src/components/DropzoneArea.js
+++ b/src/components/DropzoneArea.js
@@ -251,6 +251,7 @@ class DropzoneArea extends React.PureComponent {
             dropzoneParagraphClass,
             dropzoneText,
             filesLimit,
+            inputProps,
             maxFileSize,
             previewChipProps,
             previewGridClasses,
@@ -289,7 +290,7 @@ class DropzoneArea extends React.PureComponent {
                                 isDragReject && classes.rejectStripes,
                             )}
                         >
-                            <input {...getInputProps()} />
+                            <input {...inputProps} {...getInputProps()} />
 
                             <div className={classes.dropzoneTextStyle}>
                                 <Typography
@@ -435,6 +436,12 @@ DropzoneArea.propTypes = {
     previewText: PropTypes.string,
     /** Shows styled Material-UI Snackbar when files are dropped, deleted or rejected. */
     showAlerts: PropTypes.bool,
+    /**
+     * Attributes applied to the input element.
+     *
+     * @see See [MDN Input File attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#Additional_attributes) for available values.
+     */
+    inputProps: PropTypes.object,
     /** Clear uploaded files when component is unmounted. */
     clearOnUnmount: PropTypes.bool,
     /** List of URLs of already uploaded images.<br/>**Note:** Please take care of CORS. */

--- a/src/components/DropzoneArea.js
+++ b/src/components/DropzoneArea.js
@@ -249,6 +249,7 @@ class DropzoneArea extends React.PureComponent {
             classes,
             dropzoneClass,
             dropzoneParagraphClass,
+            dropzoneProps,
             dropzoneText,
             filesLimit,
             inputProps,
@@ -274,6 +275,7 @@ class DropzoneArea extends React.PureComponent {
         return (
             <Fragment>
                 <Dropzone
+                    {...dropzoneProps}
                     accept={acceptFiles}
                     onDropAccepted={this.handleDropAccepted}
                     onDropRejected={this.handleDropRejected}
@@ -436,6 +438,12 @@ DropzoneArea.propTypes = {
     previewText: PropTypes.string,
     /** Shows styled Material-UI Snackbar when files are dropped, deleted or rejected. */
     showAlerts: PropTypes.bool,
+    /**
+     * Props to pass to the Dropzone component.
+     *
+     * @see See [Dropzone props](https://react-dropzone.js.org/#src) for available values.
+     */
+    dropzoneProps: PropTypes.object,
     /**
      * Attributes applied to the input element.
      *

--- a/src/components/DropzoneArea.js
+++ b/src/components/DropzoneArea.js
@@ -55,9 +55,9 @@ const styles = {
     },
 };
 
-const snackbarAnchorOrigin = {
-    vertical: 'bottom',
+const defaultSnackbarAnchorOrigin = {
     horizontal: 'left',
+    vertical: 'bottom',
 };
 
 /**
@@ -246,6 +246,7 @@ class DropzoneArea extends React.PureComponent {
     render() {
         const {
             acceptedFiles,
+            alertSnackbarProps,
             classes,
             dropzoneClass,
             dropzoneParagraphClass,
@@ -340,9 +341,10 @@ class DropzoneArea extends React.PureComponent {
 
                 {showAlerts &&
                     <Snackbar
-                        anchorOrigin={snackbarAnchorOrigin}
-                        open={openSnackBar}
+                        anchorOrigin={defaultSnackbarAnchorOrigin}
                         autoHideDuration={6000}
+                        {...alertSnackbarProps}
+                        open={openSnackBar}
                         onClose={this.handleCloseSnackbar}
                     >
                         <SnackbarContentWrapper
@@ -372,6 +374,13 @@ DropzoneArea.defaultProps = {
     previewGridClasses: {},
     previewGridProps: {},
     showAlerts: true,
+    alertSnackbarProps: {
+        anchorOrigin: {
+            horizontal: 'left',
+            vertical: 'bottom',
+        },
+        autoHideDuration: 6000,
+    },
     clearOnUnmount: true,
     initialFiles: [],
     getFileLimitExceedMessage: (filesLimit) => (`Maximum allowed number of files exceeded. Only ${filesLimit} allowed`),
@@ -438,6 +447,12 @@ DropzoneArea.propTypes = {
     previewText: PropTypes.string,
     /** Shows styled Material-UI Snackbar when files are dropped, deleted or rejected. */
     showAlerts: PropTypes.bool,
+    /**
+     * Props to pass to the Material-UI Snackbar components.<br/>Requires `showAlerts` prop to be `true`.
+     *
+     * @see See [Material-UI Snackbar](https://material-ui.com/api/snackbar/#props) for available values.
+     */
+    alertSnackbarProps: PropTypes.object,
     /**
      * Props to pass to the Dropzone component.
      *

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,8 +1,9 @@
 import { ChipProps } from '@material-ui/core/Chip';
 import { DialogProps } from '@material-ui/core/Dialog';
 import { GridProps } from '@material-ui/core/Grid';
+import { SnackbarProps } from '@material-ui/core/Snackbar';
 import * as React from 'react';
-import { DropEvent } from 'react-dropzone';
+import { DropEvent, DropzoneProps } from 'react-dropzone';
 
 // DropzoneArea
 
@@ -28,6 +29,9 @@ export interface DropzoneAreaProps {
     item?: GridProps
   };
   showAlerts?: boolean;
+  alertSnackbarProps?: SnackbarProps;
+  dropzoneProps?: DropzoneProps;
+  inputProps?: React.HTMLProps<HTMLInputElement>;
   clearOnUnmount?: boolean;
   dropzoneClass?: string;
   dropzoneParagraphClass?: string;


### PR DESCRIPTION
This PR adds new customisation props to the `DropzoneArea` component.

This also updates the ESLint config to avoid throwing errors for long JSDoc comments.

This changes are based on the `master` (v3.0) branch and I'd say they can be released as `v3.1`, as soon as approved I'll backport them to the `v2.x` branch.