### PR TITLE
Add GH Action to Rebuild 'dist' on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Rebuild Dist
+
+on:
+  push:
+    branches:
+      - master
+      - v2.x
+
+env:
+  CI: true
+
+jobs:
+  build-and-commit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - run: node --version
+      - run: yarn --version
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - name: Push changes
+        uses: actions-go/push@v1
+        with:
+          author-name: ${{ github.actor }}
+          author-email: ${{ github.actor }}@users.noreply.github.com
+          commit-message: ':package: Rebuild dist @ ${{ github.sha }}'


### PR DESCRIPTION
This PR adds a Github Action to rebuild the package to the `dist` folder when pushing to `master` or to `v2.x` branches, this will avoid having to rebuild and pushing manually each time a change gets merged into one of the 2 main branches.