### PR TITLE
Avoid appending extension if present when loading external files

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -22,10 +22,7 @@ export async function createFileFromUrl(url) {
     const data = await response.blob();
     const metadata = {type: data.type};
     const filename = url.replace(/\?.+/, '').split('/').pop();
-    const ext = data.type.split('/').pop();
-    // Append extension only if not already present
-    const fullFilename = !filename?.endsWith(ext) ? `${filename}.${ext}` : filename;
-    return new File([data], fullFilename, metadata);
+    return new File([data], filename, metadata);
 }
 
 export function readFile(file) {


### PR DESCRIPTION
## Description
This PR removes the filename handling from `createFileFromUrl` helper method to avoid causing issues such as duplicated extensions.

- Fixes #135 

## Type of change
Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- [x] Interactive docs testing based on issue code

**Test Configuration**:

- Browser: Edge 81

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
