### PR TITLE
:bug: Prevent control focus rubber band drawing round the negative ma…

### DIFF
--- a/src/components/DropzoneArea.js
+++ b/src/components/DropzoneArea.js
@@ -31,6 +31,7 @@ const styles = {
         borderColor: '#C8C8C8',
         cursor: 'pointer',
         boxSizing: 'border-box',
+        overflow: 'hidden',
     },
     stripes: {
         border: 'solid',


### PR DESCRIPTION
Prevent control focus rubber band drawing round the negative margin outsize the dropzone caused by MUI Grid container spacing

## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

In some scenarios the rubber band of the focused dropzone is taking a funny shape due to the negative margin created by the PreviewList Grid container spacing.

According to an article (cited in the issue) one of the easiest ways to fix this was by setting overflow to hidden on the containing div which in this case is the dropzone div.

## Before my code changes it looks like this

![2020-05-05_12h23_40](https://user-images.githubusercontent.com/13512675/81061883-09148100-8ecd-11ea-9432-33496808269b.png)

## After it looks like this
![2020-05-05_12h25_08](https://user-images.githubusercontent.com/13512675/81062137-5f81bf80-8ecd-11ea-8513-329177fa2c40.png)






<!--
Link related issues

- Fixes # (issue)
- Fixes # (issue)
-->

- Fixes #145 

## Type of change

<!--
  Please delete options that are not relevant.
-->

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration
-->

- [x] Test A - Checked it looked identical with and without the css change other than the rubber band for 2 files
- [x] Test B - Checked it looked identical with and without the css change other than the rubber band for 8 files - to ensure that the box could still grow vertically even though the overflow was hidden

**Test Configuration**:

- Browser:

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
