### PR TITLE
:bug: Prevent control focus rubber band drawing round the negative ma…

### DIFF
--- a/src/components/DropzoneArea.js
+++ b/src/components/DropzoneArea.js
@@ -31,6 +31,7 @@ const styles = {
         borderColor: '#C8C8C8',
         cursor: 'pointer',
         boxSizing: 'border-box',
+        overflow: 'hidden',
     },
     stripes: {
         border: 'solid',


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

Backport of PR #156  

<!--
Link related issues

- Fixes # (issue)
- Fixes # (issue)
-->

-- Fixes #145 

## Type of change

<!--
  Please delete options that are not relevant.
-->

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration
-->

- [x] Test A - Ensure that the focus band doesn't take a funny shape around the negative margin, and that it works like before other than that.

**Test Configuration**:

- Browser:
Chrome, Windows

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
