### PR TITLE
getPreviewIcon fixes

### DIFF
--- a/src/components/DropzoneArea.js
+++ b/src/components/DropzoneArea.js
@@ -350,6 +350,7 @@ class DropzoneArea extends React.PureComponent {
                         <PreviewList
                             fileObjects={fileObjects}
                             handleRemove={this.handleRemove}
+                            getPreviewIcon={getPreviewIcon}
                             showFileNames={showFileNamesInPreview}
                             useChipsForPreview={useChipsForPreview}
                             previewChipProps={previewChipProps}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,6 +7,15 @@ import { DropEvent, DropzoneProps } from 'react-dropzone';
 
 // DropzoneArea
 
+export interface FileObject {
+  readonly file: File;
+  readonly data: string | ArrayBuffer | null;
+}
+
+export interface PreviewIconProps {
+  readonly classes: string;
+}
+
 export interface DropzoneAreaProps {
   acceptedFiles?: string[];
   filesLimit?: number;
@@ -20,13 +29,13 @@ export interface DropzoneAreaProps {
   useChipsForPreview?: boolean;
   previewChipProps?: ChipProps;
   previewGridClasses?: {
-    container?: string,
-    item?: string,
-    image?: string
+    container?: string;
+    item?: string;
+    image?: string;
   };
   previewGridProps?: {
-    container?: GridProps,
-    item?: GridProps
+    container?: GridProps;
+    item?: GridProps;
   };
   showAlerts?: boolean;
   alertSnackbarProps?: SnackbarProps;
@@ -48,6 +57,7 @@ export interface DropzoneAreaProps {
     acceptedFiles: string[],
     maxFileSize: number,
   ) => string;
+  getPreviewIcon?: (file: FileObject, classes: PreviewIconProps) => React.ReactElement;
 }
 
 export const DropzoneArea: React.ComponentType<DropzoneAreaProps>;


### PR DESCRIPTION
## Description

This PR fixes some issues caused after the implementation of `getPreviewIcon` prop. 

- Fixes #159 
- Fixes #161 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- [x] Interactive docs testing

**Test Configuration**:

- Browser: Edge 81

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
