### PR TITLE
Make previewChips use the grid system as well

### DIFF
--- a/src/components/DropzoneArea.md
+++ b/src/components/DropzoneArea.md
@@ -59,3 +59,30 @@ const handlePreviewIcon = (fileObject, classes) => {
   getPreviewIcon={handlePreviewIcon}
 />
 ```
+### Using chips for preview
+
+Chips use the Grid system as well, so you can customize the way they appears and benefit from the Material-UI grid customizations
+
+```jsx
+import * as React from 'react';
+import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme: Theme) => createStyles({
+    previewChip: {
+      minWidth: 160,
+      maxWidth: 210
+    }
+  }),
+)
+
+const classes = useStyles()
+
+<DropzoneArea
+  showPreviews={true}
+  showPreviewsInDropzone={false}
+  useChipsForPreview
+  previewGridProps={{container: { spacing: 1, direction: 'row' }}}
+  previewChipProps={{classes: { root: classes.previewChip } }}
+  previewText="Selected files"
+/>
+```

--- a/src/components/PreviewList.js
+++ b/src/components/PreviewList.js
@@ -60,16 +60,31 @@ function PreviewList({
 }) {
     if (useChipsForPreview) {
         return (
-            fileObjects.map((fileObject, i) => (
-                <div key={i}>
-                    <Chip
-                        variant="outlined"
-                        {...previewChipProps}
-                        label={fileObject.file.name}
-                        onDelete={handleRemove(i)}
-                    />
-                </div>
-            ))
+            <Grid
+                spacing: 1
+                direction: 'row'
+                {...previewGridProps.container}
+                container={true}
+                className={clsx(classes.root, previewGridClasses.container)}
+            >
+                {fileObjects.map((fileObject, i) => {
+                    return (
+                        <Grid
+                            {...previewGridProps.item}
+                            item={true}
+                            key={`${fileObject.file?.name ?? 'file'}-${i}`}
+                            className={classes.imageContainer}
+                        >
+                            <Chip
+                                variant="outlined"
+                                {...previewChipProps}
+                                label={fileObject.file.name}
+                                onDelete={handleRemove(i)}
+                            />
+                        </Grid>
+                    );
+                })}
+            </Grid>
         );
     }
 


### PR DESCRIPTION


## Description

Before this PR `previewGridProps` and `previewGridClasses` had no effect if we switched to `useChipsForPreview` and all the chips got stacked one below the other because of the use of a simple div.

Using the already well established **previewGrid** props allow for much more chip customizations.

Chips are now displayed inline by default but thanks to the `previewGridProps` this can be changed at any time


## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested

I've tested it personally in one of my projects

**Test Configuration**:

- Browser: Chrome

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
