### PR TITLE
Add controlled components

### DIFF
--- a/src/components/DropzoneArea.js
+++ b/src/components/DropzoneArea.js
@@ -1,115 +1,55 @@
-import Snackbar from '@material-ui/core/Snackbar';
-import Typography from '@material-ui/core/Typography';
-import {withStyles} from '@material-ui/core/styles';
-import AttachFileIcon from '@material-ui/icons/AttachFile';
-import CloudUploadIcon from '@material-ui/icons/CloudUpload';
-import clsx from 'clsx';
 import PropTypes from 'prop-types';
 import * as React from 'react';
-import {Fragment} from 'react';
-import Dropzone from 'react-dropzone';
-import {convertBytesToMbsOrKbs, createFileFromUrl, isImage, readFile} from '../helpers';
-import PreviewList from './PreviewList';
-import SnackbarContentWrapper from './SnackbarContentWrapper';
 
-const styles = ({palette, shape, spacing}) => ({
-    '@keyframes progress': {
-        '0%': {
-            backgroundPosition: '0 0',
-        },
-        '100%': {
-            backgroundPosition: '-70px 0',
-        },
-    },
-    root: {
-        position: 'relative',
-        width: '100%',
-        minHeight: '250px',
-        backgroundColor: palette.background.paper,
-        border: 'dashed',
-        borderColor: palette.divider,
-        borderRadius: shape.borderRadius,
-        boxSizing: 'border-box',
-        cursor: 'pointer',
-        overflow: 'hidden',
-    },
-    active: {
-        animation: '$progress 2s linear infinite !important',
-        // eslint-disable-next-line max-len
-        backgroundImage: `repeating-linear-gradient(-45deg, ${palette.background.paper}, ${palette.background.paper} 25px, ${palette.divider} 25px, ${palette.divider} 50px)`,
-        backgroundSize: '150% 100%',
-        border: 'solid',
-        borderColor: palette.primary.light,
-    },
-    invalid: {
-        // eslint-disable-next-line max-len
-        backgroundImage: `repeating-linear-gradient(-45deg, ${palette.error.light}, ${palette.error.light} 25px, ${palette.error.dark} 25px, ${palette.error.dark} 50px)`,
-        borderColor: palette.error.main,
-    },
-    textContainer: {
-        textAlign: 'center',
-    },
-    text: {
-        marginBottom: spacing(3),
-        marginTop: spacing(3),
-    },
-    icon: {
-        width: 51,
-        height: 51,
-        color: palette.text.primary,
-    },
-});
+import {createFileFromUrl, readFile} from '../helpers';
 
-const defaultSnackbarAnchorOrigin = {
-    horizontal: 'left',
-    vertical: 'bottom',
-};
+import DropzoneAreaBase from './DropzoneAreaBase';
 
-const defaultGetPreviewIcon = (fileObject, classes) => {
-    if (isImage(fileObject.file)) {
-        return (<img
-            className={classes.image}
-            role="presentation"
-            src={fileObject.data}
-        />);
-    }
-
-    return <AttachFileIcon className={classes.image} />;
+const splitDropzoneAreaProps = (props) => {
+    const {clearOnUnmount, initialFiles, onChange, onDelete, ...dropzoneAreaProps} = props;
+    return [{clearOnUnmount, initialFiles, onChange, onDelete}, dropzoneAreaProps];
 };
 
 /**
- * This components creates a Material-UI Dropzone, with previews and snackbar notifications.
+ * This components creates an uncontrolled Material-UI Dropzone, with previews and snackbar notifications.
+ *
+ * It supports all props of `DropzoneAreaBase` but keeps the files state internally.
+ *
+ * **Note** To listen to file changes use `onChange` event handler and notice that `onDelete` returns a `File` instance instead of `FileObject`.
  */
 class DropzoneArea extends React.PureComponent {
     state = {
         fileObjects: [],
-        openSnackBar: false,
-        snackbarMessage: '',
-        snackbarVariant: 'success',
-    };
+    }
 
     componentDidMount() {
-        this.filesArray(this.props.initialFiles);
+        this.loadInitialFiles();
     }
 
     componentWillUnmount() {
-        const {clearOnUnmount, onChange} = this.props;
+        const {clearOnUnmount} = this.props;
 
         if (clearOnUnmount) {
             this.setState({
                 fileObjects: [],
-            });
-
-            if (onChange) {
-                onChange([]);
-            }
+            }, this.notifyFileChange);
         }
     }
 
-    filesArray = async(urls) => {
+    notifyFileChange = () => {
+        const {onChange} = this.props;
+        const {fileObjects} = this.state;
+
+        if (onChange) {
+            onChange(fileObjects.map((fileObject) => fileObject.file));
+        }
+    }
+
+    loadInitialFiles = async() => {
+        const {initialFiles} = this.props;
         try {
             const fileObjs = await Promise.all(
-                urls.map(async(url) => {
+                initialFiles.map(async(url) => {
                     const file = await createFileFromUrl(url);
                     const data = await readFile(file);
 
@@ -125,63 +65,20 @@ class DropzoneArea extends React.PureComponent {
                     state.fileObjects,
                     fileObjs
                 ),
-            }),
-            () => {
-                const {onChange} = this.props;
-                const {fileObjects} = this.state;
-
-                if (onChange) {
-                    onChange(fileObjects.map((fileObject) => fileObject.file));
-                }
-            });
+            }), this.notifyFileChange);
         } catch (err) {
             console.log(err);
         }
     }
 
-    handleDropAccepted = async(acceptedFiles, evt) => {
-        const {filesLimit, getFileAddedMessage, getFileLimitExceedMessage, onDrop} = this.props;
-        const {fileObjects} = this.state;
-
-        if (filesLimit > 1 && fileObjects.length + acceptedFiles.length > filesLimit) {
-            this.setState({
-                openSnackBar: true,
-                snackbarMessage: getFileLimitExceedMessage(filesLimit),
-                snackbarVariant: 'error',
-            });
-            return;
-        }
-
-        // Notify Drop event
-        if (onDrop) {
-            onDrop(acceptedFiles, evt);
-        }
-
-        // Retrieve fileObjects data
-        const fileObjs = await Promise.all(
-            acceptedFiles.map(async(file) => {
-                const data = await readFile(file);
-                return {
-                    file,
-                    data,
-                };
-            })
-        );
-
-        // Display message
-        const message = fileObjs.reduce((msg, fileObj) => msg + getFileAddedMessage(fileObj.file.name), '');
-        this.setState({
-            openSnackBar: true,
-            snackbarMessage: message,
-            snackbarVariant: 'success',
-        });
-
+    addFiles = async(newFileObjects) => {
+        const {filesLimit} = this.props;
         // Update component state
         this.setState((state) => {
             // Handle a single file
             if (filesLimit <= 1) {
                 return {
-                    fileObjects: [].concat(fileObjs[0]),
+                    fileObjects: [].concat(newFileObjects[0]),
                 };
             }
 
@@ -189,372 +86,69 @@ class DropzoneArea extends React.PureComponent {
             return {
                 fileObjects: [].concat(
                     state.fileObjects,
-                    fileObjs
+                    newFileObjects
                 ),
             };
-        },
-        () => {
-            const {onChange} = this.props;
-            const {fileObjects} = this.state;
-
-            if (onChange) {
-                onChange(fileObjects.map((fileObject) => fileObject.file));
-            }
-        });
+        }, this.notifyFileChange);
     }
 
-    handleDropRejected = (rejectedFiles, evt) => {
-        const {acceptedFiles, getDropRejectMessage, maxFileSize, onDropRejected} = this.props;
-
-        let message = '';
-        rejectedFiles.forEach((rejectedFile) => {
-            message = getDropRejectMessage(rejectedFile, acceptedFiles, maxFileSize);
-        });
-
-        if (onDropRejected) {
-            onDropRejected(rejectedFiles, evt);
-        }
-
-        this.setState({
-            openSnackBar: true,
-            snackbarMessage: message,
-            snackbarVariant: 'error',
-        });
-    }
-
-    handleRemove = (fileIndex) => (event) => {
+    deleteFile = (removedFileObj, removedFileObjIdx) => {
         event.stopPropagation();
 
-        const {getFileRemovedMessage, onChange, onDelete} = this.props;
+        const {onDelete} = this.props;
         const {fileObjects} = this.state;
 
-        // Find removed fileObject
-        const removedFileObj = fileObjects.filter((fileObject, i) => {
-            return i === fileIndex;
-        })[0];
         // Calculate remaining fileObjects array
         const remainingFileObjs = fileObjects.filter((fileObject, i) => {
-            return i !== fileIndex;
+            return i !== removedFileObjIdx;
         });
 
-        this.setState({fileObjects: remainingFileObjs}, () => {
-            if (onDelete) {
-                onDelete(removedFileObj.file);
-            }
+        // Notify removed file
+        if (onDelete) {
+            onDelete(removedFileObj.file);
+        }
 
-            if (onChange) {
-                onChange(this.state.fileObjects.map((fileObject) => fileObject.file));
-            }
-
-            this.setState({
-                openSnackBar: true,
-                snackbarMessage: getFileRemovedMessage(removedFileObj.file.name),
-                snackbarVariant: 'info',
-            });
-        });
-    };
-
-    handleCloseSnackbar = () => {
+        // Update local state
         this.setState({
-            openSnackBar: false,
-        });
-    };
+            fileObjects: remainingFileObjs,
+        }, this.notifyFileChange);
+    }
 
     render() {
-        const {
-            acceptedFiles,
-            alertSnackbarProps,
-            classes,
-            disableRejectionFeedback,
-            dropzoneClass,
-            dropzoneParagraphClass,
-            dropzoneProps,
-            dropzoneText,
-            filesLimit,
-            getPreviewIcon,
-            inputProps,
-            maxFileSize,
-            previewChipProps,
-            previewGridClasses,
-            previewGridProps,
-            previewText,
-            showAlerts,
-            showFileNames,
-            showFileNamesInPreview,
-            showPreviews,
-            showPreviewsInDropzone,
-            useChipsForPreview,
-        } = this.props;
-        const {fileObjects, openSnackBar, snackbarMessage, snackbarVariant} = this.state;
-
-        const acceptFiles = acceptedFiles?.join(',');
-        const isMultiple = filesLimit > 1;
-        const previewsVisible = showPreviews && fileObjects.length > 0;
-        const previewsInDropzoneVisible = showPreviewsInDropzone && fileObjects.length > 0;
+        const [, dropzoneAreaProps] = splitDropzoneAreaProps(this.props);
+        const {fileObjects} = this.state;
 
         return (
-            <Fragment>
-                <Dropzone
-                    {...dropzoneProps}
-                    accept={acceptFiles}
-                    onDropAccepted={this.handleDropAccepted}
-                    onDropRejected={this.handleDropRejected}
-                    maxSize={maxFileSize}
-                    multiple={isMultiple}
-                >
-                    {({getRootProps, getInputProps, isDragActive, isDragReject}) => (
-                        <div
-                            {...getRootProps()}
-                            className={clsx(
-                                classes.root,
-                                dropzoneClass,
-                                isDragActive && classes.active,
-                                (!disableRejectionFeedback && isDragReject) && classes.invalid,
-                            )}
-                        >
-                            <input {...inputProps} {...getInputProps()} />
-
-                            <div className={classes.textContainer}>
-                                <Typography
-                                    variant="h5"
-                                    component="p"
-                                    className={clsx(classes.text, dropzoneParagraphClass)}
-                                >
-                                    {dropzoneText}
-                                </Typography>
-                                <CloudUploadIcon className={classes.icon} />
-                            </div>
-
-                            {previewsInDropzoneVisible &&
-                                <PreviewList
-                                    fileObjects={fileObjects}
-                                    handleRemove={this.handleRemove}
-                                    getPreviewIcon={getPreviewIcon}
-                                    showFileNames={showFileNames}
-                                    useChipsForPreview={useChipsForPreview}
-                                    previewChipProps={previewChipProps}
-                                    previewGridClasses={previewGridClasses}
-                                    previewGridProps={previewGridProps}
-                                />
-                            }
-                        </div>
-                    )}
-                </Dropzone>
-
-                {previewsVisible &&
-                    <Fragment>
-                        <Typography variant="subtitle1" component="span">
-                            {previewText}
-                        </Typography>
-
-                        <PreviewList
-                            fileObjects={fileObjects}
-                            handleRemove={this.handleRemove}
-                            getPreviewIcon={getPreviewIcon}
-                            showFileNames={showFileNamesInPreview}
-                            useChipsForPreview={useChipsForPreview}
-                            previewChipProps={previewChipProps}
-                            previewGridClasses={previewGridClasses}
-                            previewGridProps={previewGridProps}
-                        />
-                    </Fragment>
-                }
-
-                {((typeof showAlerts === 'boolean' && showAlerts)  || (Array.isArray(showAlerts) && showAlerts.includes(snackbarVariant))) &&
-                    <Snackbar
-                        anchorOrigin={defaultSnackbarAnchorOrigin}
-                        autoHideDuration={6000}
-                        {...alertSnackbarProps}
-                        open={openSnackBar}
-                        onClose={this.handleCloseSnackbar}
-                    >
-                        <SnackbarContentWrapper
-                            onClose={this.handleCloseSnackbar}
-                            variant={snackbarVariant}
-                            message={snackbarMessage}
-                        />
-                    </Snackbar>
-                }
-            </Fragment>
+            <DropzoneAreaBase
+                {...dropzoneAreaProps}
+                fileObjects={fileObjects}
+                onAdd={this.addFiles}
+                onDelete={this.deleteFile}
+            />
         );
     }
 }
 
 DropzoneArea.defaultProps = {
-    acceptedFiles: ['image/*', 'video/*', 'application/*'],
-    filesLimit: 3,
-    maxFileSize: 3000000,
-    dropzoneText: 'Drag and drop a file here or click',
-    previewText: 'Preview:',
-    disableRejectionFeedback: false,
-    showPreviews: false, // By default previews show up under in the dialog and inside in the standalone
-    showPreviewsInDropzone: true,
-    showFileNames: false,
-    showFileNamesInPreview: false,
-    useChipsForPreview: false,
-    previewChipProps: {},
-    previewGridClasses: {},
-    previewGridProps: {},
-    showAlerts: true,
-    alertSnackbarProps: {
-        anchorOrigin: {
-            horizontal: 'left',
-            vertical: 'bottom',
-        },
-        autoHideDuration: 6000,
-    },
     clearOnUnmount: true,
+    filesLimit: 3,
     initialFiles: [],
-    getFileLimitExceedMessage: (filesLimit) => (`Maximum allowed number of files exceeded. Only ${filesLimit} allowed`),
-    getFileAddedMessage: (fileName) => (`File ${fileName} successfully added.`),
-    getPreviewIcon: defaultGetPreviewIcon,
-    getFileRemovedMessage: (fileName) => (`File ${fileName} removed.`),
-    getDropRejectMessage: (rejectedFile, acceptedFiles, maxFileSize) => {
-        let message = `File ${rejectedFile.name} was rejected. `;
-        if (!acceptedFiles.includes(rejectedFile.type)) {
-            message += 'File type not supported. ';
-        }
-        if (rejectedFile.size > maxFileSize) {
-            message += 'File is too big. Size limit is ' + convertBytesToMbsOrKbs(maxFileSize) + '. ';
-        }
-        return message;
-    },
 };
 
 DropzoneArea.propTypes = {
-    /** @ignore */
-    classes: PropTypes.object.isRequired,
-    /** A list of file types to accept.
-     * @see See [here](https://react-dropzone.js.org/#section-accepting-specific-file-types) for more details.
-     */
-    acceptedFiles: PropTypes.arrayOf(PropTypes.string),
-    /** Maximum number of files that can be loaded into the dropzone. */
-    filesLimit: PropTypes.number,
-    /** Maximum file size (in bytes) that the dropzone will accept. */
-    maxFileSize: PropTypes.number,
-    /** Text inside the dropzone. */
-    dropzoneText: PropTypes.string,
-    /** Custom CSS class name for dropzone container. */
-    dropzoneClass: PropTypes.string,
-    /** Custom CSS class name for text inside the container. */
-    dropzoneParagraphClass: PropTypes.string,
-    /** Disable feedback effect when dropping rejected files. */
-    disableRejectionFeedback: PropTypes.bool,
-    /** Shows previews **BELOW** the dropzone. */
-    showPreviews: PropTypes.bool,
-    /** Shows preview **INSIDE** the dropzone area. */
-    showPreviewsInDropzone: PropTypes.bool,
-    /** Shows file name under the dropzone image. */
-    showFileNames: PropTypes.bool,
-    /** Shows file name under the image. */
-    showFileNamesInPreview: PropTypes.bool,
-    /** Uses deletable Material-UI Chip components to display file names. */
-    useChipsForPreview: PropTypes.bool,
-    /**
-     * Props to pass to the Material-UI Chip components.<br/>Requires `useChipsForPreview` prop to be `true`.
-     *
-     * @see See [Material-UI Chip](https://material-ui.com/api/chip/#props) for available values.
-     */
-    previewChipProps: PropTypes.object,
-    /**
-     * Custom CSS classNames for preview Grid components.<br/>
-     * Should be in the form {container: string, item: string, image: string}.
-     */
-    previewGridClasses: PropTypes.object,
-    /**
-     * Props to pass to the Material-UI Grid components.<br/>
-     * Should be in the form {container: GridProps, item: GridProps}.
-     *
-     * @see See [Material-UI Grid](https://material-ui.com/api/grid/#props) for available GridProps values.
-     */
-    previewGridProps: PropTypes.object,
-    /** The label for the file preview section. */
-    previewText: PropTypes.string,
-    /** Shows styled Material-UI Snackbar when files are dropped, deleted or rejected. */
-    showAlerts: PropTypes.oneOf([PropTypes.bool, PropTypes.arrayOf(PropTypes.string)]),
-    /**
-     * Props to pass to the Material-UI Snackbar components.<br/>Requires `showAlerts` prop to be `true`.
-     *
-     * @see See [Material-UI Snackbar](https://material-ui.com/api/snackbar/#props) for available values.
-     */
-    alertSnackbarProps: PropTypes.object,
-    /**
-     * Props to pass to the Dropzone component.
-     *
-     * @see See [Dropzone props](https://react-dropzone.js.org/#src) for available values.
-     */
-    dropzoneProps: PropTypes.object,
-    /**
-     * Attributes applied to the input element.
-     *
-     * @see See [MDN Input File attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#Additional_attributes) for available values.
-     */
-    inputProps: PropTypes.object,
+    ...DropzoneAreaBase.propTypes,
     /** Clear uploaded files when component is unmounted. */
     clearOnUnmount: PropTypes.bool,
     /** List of URLs of already uploaded images.<br/>**Note:** Please take care of CORS. */
     initialFiles: PropTypes.arrayOf(PropTypes.string),
-    /**
-     * Get alert message to display when files limit is exceed.
-     *
-     * *Default*: "Maximum allowed number of files exceeded. Only ${filesLimit} allowed"
-     *
-     * @param {number} filesLimit The `filesLimit` currently set for the component.
-     */
-    getFileLimitExceedMessage: PropTypes.func,
-    /**
-     * Get alert message to display when a new file is added.
-     *
-     * *Default*: "File ${fileName} successfully added."
-     *
-     * @param {string} fileName The newly added file name.
-     */
-    getFileAddedMessage: PropTypes.func,
-    /**
-     * Get alert message to display when a file is removed.
-     *
-     * *Default*: "File ${fileName} removed."
-     *
-     * @param {string} fileName The name of the removed file.
-     */
-    getFileRemovedMessage: PropTypes.func,
-    /**
-     * Get alert message to display when a file is rejected onDrop.
-     *
-     * *Default*: "File ${rejectedFile.name} was rejected."
-     *
-     * @param {Object} rejectedFile The file that got rejected
-     * @param {string[]} acceptedFiles The `acceptedFiles` prop currently set for the component
-     * @param {number} maxFileSize The `maxFileSize` prop currently set for the component
-     */
-    getDropRejectMessage: PropTypes.func,
-    /**
-     * A function which determines which icon to display for a file preview.
-     *
-     * *Default*: If its an image then displays a preview the image, otherwise it will display an attachment icon
-     *
-     * @param {File} objectFile The file which the preview will belong to
-     * @param {Object} classes The classes for the file preview icon, in the default case we use the 'image' className.
-     */
-    getPreviewIcon: PropTypes.func,
+    /** Maximum number of files that can be loaded into the dropzone. */
+    filesLimit: PropTypes.number,
     /**
      * Fired when the files inside dropzone change.
      *
      * @param {File[]} loadedFiles All the files currently loaded into the dropzone.
      */
     onChange: PropTypes.func,
-    /**
-     * Fired when the user drops files into the dropzone.
-     *
-     * @param {File[]} droppedFiles All the files dropped into the dropzone.
-     */
-    onDrop: PropTypes.func,
-    /**
-     * Fired when a file is rejected because of wrong file type, size or goes beyond the filesLimit.
-     *
-     * @param {File[]} rejectedFiles All the rejected files.
-     */
-    onDropRejected: PropTypes.func,
     /**
      * Fired when a file is deleted from the previews panel.
      *
@@ -563,4 +157,4 @@ DropzoneArea.propTypes = {
     onDelete: PropTypes.func,
 };
 
-export default withStyles(styles, {name: 'MuiDropzoneArea'})(DropzoneArea);
+export default DropzoneArea;

--- a/src/components/DropzoneAreaBase.js
+++ b/src/components/DropzoneAreaBase.js
@@ -1,0 +1,499 @@
+import Snackbar from '@material-ui/core/Snackbar';
+import Typography from '@material-ui/core/Typography';
+import {withStyles} from '@material-ui/core/styles';
+import AttachFileIcon from '@material-ui/icons/AttachFile';
+import CloudUploadIcon from '@material-ui/icons/CloudUpload';
+import clsx from 'clsx';
+import PropTypes from 'prop-types';
+import * as React from 'react';
+import {Fragment} from 'react';
+import Dropzone from 'react-dropzone';
+import {convertBytesToMbsOrKbs, isImage, readFile} from '../helpers';
+import PreviewList from './PreviewList';
+import SnackbarContentWrapper from './SnackbarContentWrapper';
+
+const styles = ({palette, shape, spacing}) => ({
+    '@keyframes progress': {
+        '0%': {
+            backgroundPosition: '0 0',
+        },
+        '100%': {
+            backgroundPosition: '-70px 0',
+        },
+    },
+    root: {
+        position: 'relative',
+        width: '100%',
+        minHeight: '250px',
+        backgroundColor: palette.background.paper,
+        border: 'dashed',
+        borderColor: palette.divider,
+        borderRadius: shape.borderRadius,
+        boxSizing: 'border-box',
+        cursor: 'pointer',
+        overflow: 'hidden',
+    },
+    active: {
+        animation: '$progress 2s linear infinite !important',
+        // eslint-disable-next-line max-len
+        backgroundImage: `repeating-linear-gradient(-45deg, ${palette.background.paper}, ${palette.background.paper} 25px, ${palette.divider} 25px, ${palette.divider} 50px)`,
+        backgroundSize: '150% 100%',
+        border: 'solid',
+        borderColor: palette.primary.light,
+    },
+    invalid: {
+        // eslint-disable-next-line max-len
+        backgroundImage: `repeating-linear-gradient(-45deg, ${palette.error.light}, ${palette.error.light} 25px, ${palette.error.dark} 25px, ${palette.error.dark} 50px)`,
+        borderColor: palette.error.main,
+    },
+    textContainer: {
+        textAlign: 'center',
+    },
+    text: {
+        marginBottom: spacing(3),
+        marginTop: spacing(3),
+    },
+    icon: {
+        width: 51,
+        height: 51,
+        color: palette.text.primary,
+    },
+});
+
+const defaultSnackbarAnchorOrigin = {
+    horizontal: 'left',
+    vertical: 'bottom',
+};
+
+const defaultGetPreviewIcon = (fileObject, classes) => {
+    if (isImage(fileObject.file)) {
+        return (<img
+            className={classes.image}
+            role="presentation"
+            src={fileObject.data}
+        />);
+    }
+
+    return <AttachFileIcon className={classes.image} />;
+};
+
+/**
+ * This components creates a Material-UI Dropzone, with previews and snackbar notifications.
+ */
+class DropzoneAreaBase extends React.PureComponent {
+    state = {
+        openSnackBar: false,
+        snackbarMessage: '',
+        snackbarVariant: 'success',
+    };
+
+    handleDropAccepted = async(acceptedFiles, evt) => {
+        const {fileObjects, filesLimit, getFileAddedMessage, getFileLimitExceedMessage, onAdd, onDrop} = this.props;
+
+        if (filesLimit > 1 && fileObjects.length + acceptedFiles.length > filesLimit) {
+            this.setState({
+                openSnackBar: true,
+                snackbarMessage: getFileLimitExceedMessage(filesLimit),
+                snackbarVariant: 'error',
+            });
+            return;
+        }
+
+        // Notify Drop event
+        if (onDrop) {
+            onDrop(acceptedFiles, evt);
+        }
+
+        // Retrieve fileObjects data
+        const fileObjs = await Promise.all(
+            acceptedFiles.map(async(file) => {
+                const data = await readFile(file);
+                return {
+                    file,
+                    data,
+                };
+            })
+        );
+
+        // Notify added files
+        if (onAdd) {
+            onAdd(fileObjs);
+        }
+
+        // Display message
+        const message = fileObjs.reduce((msg, fileObj) => msg + getFileAddedMessage(fileObj.file.name), '');
+        this.setState({
+            openSnackBar: true,
+            snackbarMessage: message,
+            snackbarVariant: 'success',
+        });
+    }
+
+    handleDropRejected = (rejectedFiles, evt) => {
+        const {acceptedFiles, getDropRejectMessage, maxFileSize, onDropRejected} = this.props;
+
+        let message = '';
+        rejectedFiles.forEach((rejectedFile) => {
+            message = getDropRejectMessage(rejectedFile, acceptedFiles, maxFileSize);
+        });
+
+        if (onDropRejected) {
+            onDropRejected(rejectedFiles, evt);
+        }
+
+        this.setState({
+            openSnackBar: true,
+            snackbarMessage: message,
+            snackbarVariant: 'error',
+        });
+    }
+
+    handleRemove = (fileIndex) => (event) => {
+        event.stopPropagation();
+
+        const {fileObjects, getFileRemovedMessage, onDelete} = this.props;
+
+        // Find removed fileObject
+        const removedFileObj = fileObjects[fileIndex];
+
+        // Notify removed file
+        if (onDelete) {
+            onDelete(removedFileObj, fileIndex);
+        }
+
+        this.setState({
+            openSnackBar: true,
+            snackbarMessage: getFileRemovedMessage(removedFileObj.file.name),
+            snackbarVariant: 'info',
+        });
+    };
+
+    handleCloseSnackbar = () => {
+        this.setState({
+            openSnackBar: false,
+        });
+    };
+
+    render() {
+        const {
+            acceptedFiles,
+            alertSnackbarProps,
+            classes,
+            disableRejectionFeedback,
+            dropzoneClass,
+            dropzoneParagraphClass,
+            dropzoneProps,
+            dropzoneText,
+            fileObjects,
+            filesLimit,
+            getPreviewIcon,
+            inputProps,
+            maxFileSize,
+            previewChipProps,
+            previewGridClasses,
+            previewGridProps,
+            previewText,
+            showAlerts,
+            showFileNames,
+            showFileNamesInPreview,
+            showPreviews,
+            showPreviewsInDropzone,
+            useChipsForPreview,
+        } = this.props;
+        const {openSnackBar, snackbarMessage, snackbarVariant} = this.state;
+
+        const acceptFiles = acceptedFiles?.join(',');
+        const isMultiple = filesLimit > 1;
+        const previewsVisible = showPreviews && fileObjects.length > 0;
+        const previewsInDropzoneVisible = showPreviewsInDropzone && fileObjects.length > 0;
+
+        return (
+            <Fragment>
+                <Dropzone
+                    {...dropzoneProps}
+                    accept={acceptFiles}
+                    onDropAccepted={this.handleDropAccepted}
+                    onDropRejected={this.handleDropRejected}
+                    maxSize={maxFileSize}
+                    multiple={isMultiple}
+                >
+                    {({getRootProps, getInputProps, isDragActive, isDragReject}) => (
+                        <div
+                            {...getRootProps()}
+                            className={clsx(
+                                classes.root,
+                                dropzoneClass,
+                                isDragActive && classes.active,
+                                (!disableRejectionFeedback && isDragReject) && classes.invalid,
+                            )}
+                        >
+                            <input {...inputProps} {...getInputProps()} />
+
+                            <div className={classes.textContainer}>
+                                <Typography
+                                    variant="h5"
+                                    component="p"
+                                    className={clsx(classes.text, dropzoneParagraphClass)}
+                                >
+                                    {dropzoneText}
+                                </Typography>
+                                <CloudUploadIcon className={classes.icon} />
+                            </div>
+
+                            {previewsInDropzoneVisible &&
+                                <PreviewList
+                                    fileObjects={fileObjects}
+                                    handleRemove={this.handleRemove}
+                                    getPreviewIcon={getPreviewIcon}
+                                    showFileNames={showFileNames}
+                                    useChipsForPreview={useChipsForPreview}
+                                    previewChipProps={previewChipProps}
+                                    previewGridClasses={previewGridClasses}
+                                    previewGridProps={previewGridProps}
+                                />
+                            }
+                        </div>
+                    )}
+                </Dropzone>
+
+                {previewsVisible &&
+                    <Fragment>
+                        <Typography variant="subtitle1" component="span">
+                            {previewText}
+                        </Typography>
+
+                        <PreviewList
+                            fileObjects={fileObjects}
+                            handleRemove={this.handleRemove}
+                            getPreviewIcon={getPreviewIcon}
+                            showFileNames={showFileNamesInPreview}
+                            useChipsForPreview={useChipsForPreview}
+                            previewChipProps={previewChipProps}
+                            previewGridClasses={previewGridClasses}
+                            previewGridProps={previewGridProps}
+                        />
+                    </Fragment>
+                }
+
+                {((typeof showAlerts === 'boolean' && showAlerts) ||
+                    (Array.isArray(showAlerts) && showAlerts.includes(snackbarVariant))) &&
+                    <Snackbar
+                        anchorOrigin={defaultSnackbarAnchorOrigin}
+                        autoHideDuration={6000}
+                        {...alertSnackbarProps}
+                        open={openSnackBar}
+                        onClose={this.handleCloseSnackbar}
+                    >
+                        <SnackbarContentWrapper
+                            onClose={this.handleCloseSnackbar}
+                            variant={snackbarVariant}
+                            message={snackbarMessage}
+                        />
+                    </Snackbar>
+                }
+            </Fragment>
+        );
+    }
+}
+
+DropzoneAreaBase.defaultProps = {
+    acceptedFiles: ['image/*', 'video/*', 'application/*'],
+    filesLimit: 3,
+    fileObjects: [],
+    maxFileSize: 3000000,
+    dropzoneText: 'Drag and drop a file here or click',
+    previewText: 'Preview:',
+    disableRejectionFeedback: false,
+    showPreviews: false, // By default previews show up under in the dialog and inside in the standalone
+    showPreviewsInDropzone: true,
+    showFileNames: false,
+    showFileNamesInPreview: false,
+    useChipsForPreview: false,
+    previewChipProps: {},
+    previewGridClasses: {},
+    previewGridProps: {},
+    showAlerts: true,
+    alertSnackbarProps: {
+        anchorOrigin: {
+            horizontal: 'left',
+            vertical: 'bottom',
+        },
+        autoHideDuration: 6000,
+    },
+    getFileLimitExceedMessage: (filesLimit) => (`Maximum allowed number of files exceeded. Only ${filesLimit} allowed`),
+    getFileAddedMessage: (fileName) => (`File ${fileName} successfully added.`),
+    getPreviewIcon: defaultGetPreviewIcon,
+    getFileRemovedMessage: (fileName) => (`File ${fileName} removed.`),
+    getDropRejectMessage: (rejectedFile, acceptedFiles, maxFileSize) => {
+        let message = `File ${rejectedFile.name} was rejected. `;
+        if (!acceptedFiles.includes(rejectedFile.type)) {
+            message += 'File type not supported. ';
+        }
+        if (rejectedFile.size > maxFileSize) {
+            message += 'File is too big. Size limit is ' + convertBytesToMbsOrKbs(maxFileSize) + '. ';
+        }
+        return message;
+    },
+};
+
+export const FileObjectShape = PropTypes.shape({
+    file: PropTypes.object,
+    data: PropTypes.any,
+});
+
+DropzoneAreaBase.propTypes = {
+    /** @ignore */
+    classes: PropTypes.object.isRequired,
+    /** A list of file types to accept.
+     * @see See [here](https://react-dropzone.js.org/#section-accepting-specific-file-types) for more details.
+     */
+    acceptedFiles: PropTypes.arrayOf(PropTypes.string),
+    /** Maximum number of files that can be loaded into the dropzone. */
+    filesLimit: PropTypes.number,
+    /** Currently loaded files. */
+    fileObjects: PropTypes.arrayOf(FileObjectShape),
+    /** Maximum file size (in bytes) that the dropzone will accept. */
+    maxFileSize: PropTypes.number,
+    /** Text inside the dropzone. */
+    dropzoneText: PropTypes.string,
+    /** Custom CSS class name for dropzone container. */
+    dropzoneClass: PropTypes.string,
+    /** Custom CSS class name for text inside the container. */
+    dropzoneParagraphClass: PropTypes.string,
+    /** Disable feedback effect when dropping rejected files. */
+    disableRejectionFeedback: PropTypes.bool,
+    /** Shows previews **BELOW** the dropzone. */
+    showPreviews: PropTypes.bool,
+    /** Shows preview **INSIDE** the dropzone area. */
+    showPreviewsInDropzone: PropTypes.bool,
+    /** Shows file name under the dropzone image. */
+    showFileNames: PropTypes.bool,
+    /** Shows file name under the image. */
+    showFileNamesInPreview: PropTypes.bool,
+    /** Uses deletable Material-UI Chip components to display file names. */
+    useChipsForPreview: PropTypes.bool,
+    /**
+     * Props to pass to the Material-UI Chip components.<br/>Requires `useChipsForPreview` prop to be `true`.
+     *
+     * @see See [Material-UI Chip](https://material-ui.com/api/chip/#props) for available values.
+     */
+    previewChipProps: PropTypes.object,
+    /**
+     * Custom CSS classNames for preview Grid components.<br/>
+     * Should be in the form {container: string, item: string, image: string}.
+     */
+    previewGridClasses: PropTypes.object,
+    /**
+     * Props to pass to the Material-UI Grid components.<br/>
+     * Should be in the form {container: GridProps, item: GridProps}.
+     *
+     * @see See [Material-UI Grid](https://material-ui.com/api/grid/#props) for available GridProps values.
+     */
+    previewGridProps: PropTypes.object,
+    /** The label for the file preview section. */
+    previewText: PropTypes.string,
+    /**
+     * Shows styled Material-UI Snackbar when files are dropped, deleted or rejected.
+     *
+     * - can be a boolean ("global" `true` or `false` for all alerts).
+     * - can be an array, with values 'error', 'info', 'success' to select to view only certain alerts:
+     *  - showAlerts={['error']} for only errors.
+     *  - showAlerts={['error', 'info']} for both errors and info.
+     *  - showAlerts={['error', 'success', 'info']} is same as showAlerts={true}.
+     *  - showAlerts={[]} is same as showAlerts={false}.
+     */
+    showAlerts: PropTypes.oneOf([
+        PropTypes.bool,
+        PropTypes.arrayOf(PropTypes.string),
+    ]),
+    /**
+     * Props to pass to the Material-UI Snackbar components.<br/>Requires `showAlerts` prop to be `true`.
+     *
+     * @see See [Material-UI Snackbar](https://material-ui.com/api/snackbar/#props) for available values.
+     */
+    alertSnackbarProps: PropTypes.object,
+    /**
+     * Props to pass to the Dropzone component.
+     *
+     * @see See [Dropzone props](https://react-dropzone.js.org/#src) for available values.
+     */
+    dropzoneProps: PropTypes.object,
+    /**
+     * Attributes applied to the input element.
+     *
+     * @see See [MDN Input File attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#Additional_attributes) for available values.
+     */
+    inputProps: PropTypes.object,
+    /**
+     * Get alert message to display when files limit is exceed.
+     *
+     * *Default*: "Maximum allowed number of files exceeded. Only ${filesLimit} allowed"
+     *
+     * @param {number} filesLimit The `filesLimit` currently set for the component.
+     */
+    getFileLimitExceedMessage: PropTypes.func,
+    /**
+     * Get alert message to display when a new file is added.
+     *
+     * *Default*: "File ${fileName} successfully added."
+     *
+     * @param {string} fileName The newly added file name.
+     */
+    getFileAddedMessage: PropTypes.func,
+    /**
+     * Get alert message to display when a file is removed.
+     *
+     * *Default*: "File ${fileName} removed."
+     *
+     * @param {string} fileName The name of the removed file.
+     */
+    getFileRemovedMessage: PropTypes.func,
+    /**
+     * Get alert message to display when a file is rejected onDrop.
+     *
+     * *Default*: "File ${rejectedFile.name} was rejected."
+     *
+     * @param {Object} rejectedFile The file that got rejected
+     * @param {string[]} acceptedFiles The `acceptedFiles` prop currently set for the component
+     * @param {number} maxFileSize The `maxFileSize` prop currently set for the component
+     */
+    getDropRejectMessage: PropTypes.func,
+    /**
+     * A function which determines which icon to display for a file preview.
+     *
+     * *Default*: If its an image then displays a preview the image, otherwise it will display an attachment icon
+     *
+     * @param {FileObject} objectFile The file which the preview will belong to
+     * @param {Object} classes The classes for the file preview icon, in the default case we use the 'image' className.
+     */
+    getPreviewIcon: PropTypes.func,
+    /**
+     * Fired when new files are added to dropzone.
+     *
+     * @param {FileObject[]} newFiles The new files added to the dropzone.
+     */
+    onAdd: PropTypes.func,
+    /**
+     * Fired when a file is deleted from the previews panel.
+     *
+     * @param {FileObject} deletedFileObject The file that was removed.
+     * @param {number} index The index of the removed file object.
+     */
+    onDelete: PropTypes.func,
+    /**
+     * Fired when the user drops files into the dropzone.
+     *
+     * @param {File[]} droppedFiles All the files dropped into the dropzone.
+     * @param {Event} event The react-dropzone drop event.
+     */
+    onDrop: PropTypes.func,
+    /**
+     * Fired when a file is rejected because of wrong file type, size or goes beyond the filesLimit.
+     *
+     * @param {File[]} rejectedFiles All the rejected files.
+     * @param {Event} event The react-dropzone drop event.
+     */
+    onDropRejected: PropTypes.func,
+};
+
+export default withStyles(styles, {name: 'MuiDropzoneArea'})(DropzoneAreaBase);

--- a/src/components/DropzoneAreaBase.md
+++ b/src/components/DropzoneAreaBase.md
@@ -1,0 +1,72 @@
+### Import
+
+```jsx static
+import { DropzoneAreaBase } from 'material-ui-dropzone';
+```
+
+### Basic usage
+
+```jsx
+<DropzoneAreaBase
+  onAdd={(fileObjs) => console.log('Added Files:', fileObjs)}
+  onDelete={(fileObj) => console.log('Removed File:', fileObj)}
+/>
+```
+
+### Accept only images
+
+```jsx
+<DropzoneAreaBase
+  acceptedFiles={['image/*']}
+  dropzoneText={"Drag and drop an image here or click"}
+  onChange={(files) => console.log('Files:', files)}
+/>
+```
+
+### Custom Preview Icon
+
+Demonstration of how to customize the preview icon for:
+
+* PDF files
+* Video
+* Audio
+* Word Documents
+
+```jsx
+import React, { useState } from 'react';
+import { AttachFile, AudioTrack, Description, PictureAsPdf, Theaters } from '@material-ui/icons';
+
+const handlePreviewIcon = (fileObject, classes) => {
+  const {type} = fileObject.file
+  const iconProps = {
+    className : classes.image,
+  }
+
+  if (type.startsWith("video/")) return <Theaters {...iconProps} />
+  if (type.startsWith("audio/")) return <AudioTrack {...iconProps} />
+
+  switch (type) {
+    case "application/msword":
+    case "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+      return <Description {...iconProps} />
+    case "application/pdf":
+      return <PictureAsPdf {...iconProps} />
+    default:
+      return <AttachFile {...iconProps} />
+  }
+}
+
+const [fileObjects, setFileObjects] = useState([]);
+
+<DropzoneAreaBase
+  fileObjects={fileObjects}
+  onAdd={newFileObjs => {
+    console.log('onAdd', newFileObjs);
+    setFileObjects([].concat(fileObjects, newFileObjs));
+  }}
+  onDelete={deleteFileObj => {
+    console.log('onDelete', deleteFileObj);
+  }}
+  getPreviewIcon={handlePreviewIcon}
+/>
+```

--- a/src/components/DropzoneDialogBase.js
+++ b/src/components/DropzoneDialogBase.js
@@ -1,0 +1,163 @@
+import Button from '@material-ui/core/Button';
+import Dialog from '@material-ui/core/Dialog';
+import DialogActions from '@material-ui/core/DialogActions';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import PropTypes from 'prop-types';
+import * as React from 'react';
+
+import DropzoneAreaBase from './DropzoneAreaBase';
+
+// Split props related to DropzoneDialog from DropzoneArea ones
+function splitDropzoneDialogProps(allProps) {
+    const {
+        cancelButtonText,
+        dialogProps,
+        dialogTitle,
+        fullWidth,
+        maxWidth,
+        onClose,
+        onSave,
+        open,
+        submitButtonText,
+        ...dropzoneAreaProps
+    } = allProps;
+
+    return [
+        {
+            cancelButtonText,
+            dialogProps,
+            dialogTitle,
+            fullWidth,
+            maxWidth,
+            onClose,
+            onSave,
+            open,
+            submitButtonText,
+        },
+        dropzoneAreaProps,
+    ];
+}
+
+/**
+ * This component provides the DropzoneArea inside of a Material-UI Dialog.
+ *
+ * It supports all the Props and Methods from `DropzoneAreaBase`.
+ */
+class DropzoneDialogBase extends React.PureComponent {
+    render() {
+        const [dropzoneDialogProps, dropzoneAreaProps] = splitDropzoneDialogProps(this.props);
+        const {
+            cancelButtonText,
+            dialogProps,
+            dialogTitle,
+            fullWidth,
+            maxWidth,
+            onClose,
+            onSave,
+            open,
+            submitButtonText,
+        } = dropzoneDialogProps;
+
+        // Submit button state
+        const submitDisabled = dropzoneAreaProps.fileObjects.length === 0;
+
+        return (
+            <Dialog
+                {...dialogProps}
+                fullWidth={fullWidth}
+                maxWidth={maxWidth}
+                onClose={onClose}
+                open={open}
+            >
+                <DialogTitle>{dialogTitle}</DialogTitle>
+
+                <DialogContent>
+                    <DropzoneAreaBase
+                        {...dropzoneAreaProps}
+                    />
+                </DialogContent>
+
+                <DialogActions>
+                    <Button
+                        color="primary"
+                        onClick={onClose}
+                    >
+                        {cancelButtonText}
+                    </Button>
+
+                    <Button
+                        color="primary"
+                        disabled={submitDisabled}
+                        onClick={onSave}
+                    >
+                        {submitButtonText}
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        );
+    }
+}
+
+DropzoneDialogBase.defaultProps = {
+    open: false,
+    dialogTitle: 'Upload file',
+    dialogProps: {},
+    fullWidth: true,
+    maxWidth: 'sm',
+    cancelButtonText: 'Cancel',
+    submitButtonText: 'Submit',
+    showPreviews: true,
+    showPreviewsInDropzone: false,
+    showFileNamesInPreview: true,
+};
+
+DropzoneDialogBase.propTypes = {
+    ...DropzoneAreaBase.propTypes,
+    /** Sets whether the dialog is open or closed. */
+    open: PropTypes.bool,
+    /** The Dialog title. */
+    dialogTitle: PropTypes.string,
+    /**
+     * Props to pass to the Material-UI Dialog components.
+     * @see See [Material-UI Dialog](https://material-ui.com/api/dialog/#props) for available values.
+     */
+    dialogProps: PropTypes.object,
+    /**
+     * If `true`, the dialog stretches to `maxWidth`.<br/>
+     * Notice that the dialog width grow is limited by the default margin.
+     */
+    fullWidth: PropTypes.bool,
+    /**
+     * Determine the max-width of the dialog. The dialog width grows with the size of the screen.<br/>
+     * Set to `false` to disable `maxWidth`.
+     */
+    maxWidth: PropTypes.string,
+    /** Cancel button text in dialog. */
+    cancelButtonText: PropTypes.string,
+    /** Submit button text in dialog. */
+    submitButtonText: PropTypes.string,
+    /**
+     * Fired when the modal is closed.
+     *
+     * @param {SyntheticEvent} event The react `SyntheticEvent`
+     */
+    onClose: PropTypes.func,
+    /**
+     * Fired when the user clicks the Submit button.
+     *
+     * @param {SyntheticEvent} event The react `SyntheticEvent`
+     */
+    onSave: PropTypes.func,
+    /**
+     * Shows previews **BELOW** the dropzone.<br/>
+     * **Note:** By default previews show up under in the Dialog and inside in the standalone.
+     */
+    showPreviews: PropTypes.bool,
+    /** Shows preview **INSIDE** the dropzone area. */
+    showPreviewsInDropzone: PropTypes.bool,
+    /** Shows file name under the image. */
+    showFileNamesInPreview: PropTypes.bool,
+};
+
+export default DropzoneDialogBase;

--- a/src/components/DropzoneDialogBase.md
+++ b/src/components/DropzoneDialogBase.md
@@ -1,0 +1,43 @@
+### Import
+
+```jsx static
+import { DropzoneDialogBase } from 'material-ui-dropzone';
+```
+
+### Basic usage
+
+```jsx
+import Button from '@material-ui/core/Button';
+
+const [open, setOpen] = React.useState(false);
+const [fileObjects, setFileObjects] = React.useState([]);
+
+<div>
+  <Button variant="contained" color="primary" onClick={() => setOpen(true)}>
+    Add Image
+  </Button>
+
+  <DropzoneDialogBase
+    acceptedFiles={['image/*']}
+    fileObjects={fileObjects}
+    cancelButtonText={"cancel"}
+    submitButtonText={"submit"}
+    maxFileSize={5000000}
+    open={open}
+    onAdd={newFileObjs => {
+      console.log('onAdd', newFileObjs);
+      setFileObjects([].concat(fileObjects, newFileObjs));
+    }}
+    onDelete={deleteFileObj => {
+      console.log('onDelete', deleteFileObj);
+    }}
+    onClose={() => setOpen(false)}
+    onSave={() => {
+      console.log('onSave', fileObjects);
+      setOpen(false);
+    }}
+    showPreviews={true}
+    showFileNamesInPreview={true}
+  />
+</div>
+```

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 export {default as DropzoneArea} from './components/DropzoneArea';
 export {default as DropzoneAreaBase} from './components/DropzoneAreaBase';
 export {default as DropzoneDialog} from './components/DropzoneDialog';
+export {default as DropzoneDialogBase} from './components/DropzoneDialogBase';

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,3 @@
 export {default as DropzoneArea} from './components/DropzoneArea';
+export {default as DropzoneAreaBase} from './components/DropzoneAreaBase';
 export {default as DropzoneDialog} from './components/DropzoneDialog';


### PR DESCRIPTION
## Description

This PR introduces 2 new components (`DropzoneAreaBase` and `DropzoneDialogBase`) which are the new 'stateless' base for `DropzoneArea` and `DropzoneDialog` (which are now simple wrapper to add state).

The 2 base components are exported to allow 'controlled' usages as previously requested.

- Fixes #75 
- Fixes #167 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested

- [x] Interactive docs testing

**Test Configuration**:

- Browser: Edge 81

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
