### PR TITLE
make fileObjects optional fix Yuvaleros/material-ui-dropzone#184

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -68,8 +68,8 @@ export type DropzoneAreaBaseProps = {
 export const DropzoneAreaBase: React.ComponentType<DropzoneAreaBaseProps>;
 
 // DropzoneArea
-
-export type DropzoneAreaProps = DropzoneAreaBaseProps & {
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
+export type DropzoneAreaProps = Omit<DropzoneAreaBaseProps, 'fileObjects'> & {
   clearOnUnmount?: boolean;
   initialFiles?: string[];
   onChange?: (files: File[]) => void;
@@ -80,7 +80,7 @@ export const DropzoneArea: React.ComponentType<DropzoneAreaProps>;
 
 // DropzoneDialogBase
 
-export type DropzoneDialogBaseProps = DropzoneAreaBaseProps & {
+export type DropzoneDialogBaseProps = Omit<DropzoneAreaBaseProps, 'fileObjects'> & {
   cancelButtonText?: string;
   dialogProps?: DialogProps;
   dialogTitle?: string;


### PR DESCRIPTION
## Description

fix the type error of fileObjects in DropzoneAreaProps

- Fixes # 184

fileObjexts is required by DropzoneAreaBase, but is provided internal by DropzoneArea

## Type of change

- Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested
copy src/index.d.ts file into my node_modules/material-ui-dropzone/dist/index.d.ts can typescript error disappear

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


Another option is maybe to split DropzoneAreaBaseProps into two part instead of using the typescript Pick and Exclude