### PR TITLE
Add 'Publish to NPM' Github Action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+# Based on the solution proposed here
+#   https://sergiodxa.com/articles/github-actions-npm-publish/
+#
+
+name: Publish to NPM
+
+on:
+  release:
+    types: [published]
+
+env:
+  CI: true
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v2
+
+      - run: node --version
+      - run: yarn --version
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build
+        run: yarn build
+
+      - name: Publish to NPM
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
## Description

This PR adds a new Github Action to streamline and simplify the releasing process of the module.

The action is triggered when creating a new Release on Github and will build and publish the package to NPM.
## Type of change

- Internal (adding a Github Action)

## References

This PR is inspired by the article [Automatically Publish to npm using GitHub Actions](https://sergiodxa.com/articles/github-actions-npm-publish/).

## Notes

@Yuvaleros after merging this PR, a few setup steps are required in order to make it work.

Follow the steps highlighted in the `Configure the Secret` section of the article mentioned above ([ref](https://sergiodxa.com/articles/github-actions-npm-publish/)) to create a new token on NPM and set the `NPM_TOKEN` secret on Github.
