### PR TITLE
Show remove buttons when they have focus.

### DIFF
--- a/src/components/PreviewList.js
+++ b/src/components/PreviewList.js
@@ -41,6 +41,9 @@ const styles = ({palette, shape, spacing}) => ({
         right: spacing(-1),
         width: 40,
         height: 40,
+        '&:focus': {
+            opacity: 1,
+        },
     },
 });
 


### PR DESCRIPTION
## Description
Show the "remove image"-button when it has keyboard focus.
- Fixes #190 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested
1. Run `yarn docs:dev`.
1. Open the link listed in the console (`localhost:6060`).
1. Upload a file in one of the dropzones.
1. Press `tab` on the keyboard.

**Test Configuration**:

- Browser: FireFox 76.0

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
