### PR TITLE
Fix `filesLimit`  error message

### DIFF
--- a/src/components/DropzoneAreaBase.js
+++ b/src/components/DropzoneAreaBase.js
@@ -130,12 +130,24 @@ class DropzoneAreaBase extends React.PureComponent {
     }
 
     handleDropRejected = (rejectedFiles, evt) => {
-        const {acceptedFiles, getDropRejectMessage, maxFileSize, onDropRejected} = this.props;
+        const {
+            acceptedFiles,
+            filesLimit,
+            fileObjects,
+            getDropRejectMessage,
+            getFileLimitExceedMessage,
+            maxFileSize,
+            onDropRejected,
+        } = this.props;
 
         let message = '';
-        rejectedFiles.forEach((rejectedFile) => {
-            message = getDropRejectMessage(rejectedFile, acceptedFiles, maxFileSize);
-        });
+        if (fileObjects.length + rejectedFiles.length > filesLimit) {
+            message = getFileLimitExceedMessage(filesLimit);
+        } else {
+            rejectedFiles.forEach((rejectedFile) => {
+                message = getDropRejectMessage(rejectedFile, acceptedFiles, maxFileSize);
+            });
+        }
 
         if (onDropRejected) {
             onDropRejected(rejectedFiles, evt);


### PR DESCRIPTION
## Description

This PR fixes the logic to display the correct error message when dropping more than `filesLimit` files (in particular when `filesLimit` is set to `1`).

- Fixes #196 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- [x] Interactive docs testing

**Test Configuration**:

- Browser: Edge 83

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
