### PR TITLE
 🐛 Use `justify` prop instead of `justifyContent`  in the material-ui Grid component   for v4.x 

### DIFF
--- a/src/components/DropzoneAreaBase.js
+++ b/src/components/DropzoneAreaBase.js
@@ -35,7 +35,7 @@ const styles = ({palette, shape, spacing}) => ({
         cursor: 'pointer',
         overflow: 'hidden',
         flexDirection: 'column',
-        justifyContent: 'center',
+        justify: 'center',
     },
     active: {
         animation: '$progress 2s linear infinite !important',
@@ -250,7 +250,7 @@ class DropzoneAreaBase extends React.PureComponent {
                         >
                             <input {...inputProps} {...getInputProps()} />
 
-                            <Grid container className={classes.textContainer} direction="column" justifyContent="center" alignItems="center">
+                            <Grid container className={classes.textContainer} direction="column" justify="center" alignItems="center">
                                 <Typography
                                     variant="h5"
                                     component="p"

--- a/src/components/DropzoneAreaBase.js
+++ b/src/components/DropzoneAreaBase.js
@@ -35,7 +35,7 @@ const styles = ({palette, shape, spacing}) => ({
         cursor: 'pointer',
         overflow: 'hidden',
         flexDirection: 'column',
-        justify: 'center',
+        justifyContent: 'center',
     },
     active: {
         animation: '$progress 2s linear infinite !important',


### PR DESCRIPTION
## Description
`material-ui/core` uses `justify` prop instead of `justifyContent`. The component Grid inside `DropzoneAreaBase` uses `justifyContent`
Thus resulting in this warning
```javascript
Warning: React does not recognize the `justifyContent` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `justifycontent` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in div (created by ForwardRef(Grid))
    in ForwardRef(Grid) (created by WithStyles(ForwardRef(Grid)))
    in WithStyles(ForwardRef(Grid)) (created by Dropzone)
    in div (created by Dropzone)
    in Dropzone (created by DropzoneAreaBase)
    in DropzoneAreaBase (created by WithStyles(DropzoneAreaBase))
    in WithStyles(DropzoneAreaBase) (created by DropzoneArea)
    in DropzoneArea (at DropUploadImages.js:5)
    in DropUploadImages (at MyCompomentDropUpload.js:227)
```
Related to issue #166

## Type of change

Just removed `justifyContent` from the Grid component et used `justify`

- Bug fix (non-breaking change which fixes an issue)


