### PR TITLE
:lipstick: Snackbar icons margins

### DIFF
--- a/src/components/SnackbarContentWrapper.js
+++ b/src/components/SnackbarContentWrapper.js
@@ -33,11 +33,13 @@ const styles = (theme) => ({
     message: {
         display: 'flex',
         alignItems: 'center',
+        '& > svg': {
+            marginRight: theme.spacing(1),
+        },
     },
     icon: {
         fontSize: 20,
         opacity: 0.9,
-        marginRight: theme.spacing(1),
     },
     closeButton: {},
 });


### PR DESCRIPTION
## Description
Hi, guys! 

Before: 
<img width="395" alt="Снимок экрана 2020-07-28 в 12 03 02" src="https://user-images.githubusercontent.com/3195714/88643452-608c4c80-d0ca-11ea-837f-7435440d54b8.png">
After:
<img width="392" alt="Снимок экрана 2020-07-28 в 12 03 16" src="https://user-images.githubusercontent.com/3195714/88643454-61bd7980-d0ca-11ea-8056-5ba36baf3c69.png">
Please note on close icon

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- [x]  Interactive docs testing

**Test Configuration**:

- Browser: chrome 84.0.4147.89


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
