### PR TITLE
✨ Allow all filetypes by default

### DIFF
--- a/src/components/DropzoneAreaBase.js
+++ b/src/components/DropzoneAreaBase.js
@@ -317,7 +317,7 @@ class DropzoneAreaBase extends React.PureComponent {
 }
 
 DropzoneAreaBase.defaultProps = {
-    acceptedFiles: ['image/*', 'video/*', 'application/*'],
+    acceptedFiles: [],
     filesLimit: 3,
     fileObjects: [],
     maxFileSize: 3000000,


### PR DESCRIPTION
## Description

This PR changes the default `acceptedFiles` default prop to allow dropping all file types.

- Fixes #214 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested

- [x] Interactive docs testing

**Test Configuration**:

- Browser: Edge 81

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
