### PR TITLE
:sparkles: Custom dropzone icon

### DIFF
--- a/src/components/DropzoneAreaBase.js
+++ b/src/components/DropzoneAreaBase.js
@@ -207,6 +207,7 @@ class DropzoneAreaBase extends React.PureComponent {
             fileObjects,
             filesLimit,
             getPreviewIcon,
+            Icon,
             inputProps,
             maxFileSize,
             previewChipProps,
@@ -257,7 +258,11 @@ class DropzoneAreaBase extends React.PureComponent {
                                 >
                                     {dropzoneText}
                                 </Typography>
-                                <CloudUploadIcon className={classes.icon} />
+                                {Icon ? (
+                                    <Icon className={classes.icon} />
+                                ) : (
+                                    <CloudUploadIcon className={classes.icon} />
+                                )}
                             </div>
 
                             {previewsInDropzoneVisible &&
@@ -370,6 +375,8 @@ DropzoneAreaBase.propTypes = {
     acceptedFiles: PropTypes.arrayOf(PropTypes.string),
     /** Maximum number of files that can be loaded into the dropzone. */
     filesLimit: PropTypes.number,
+    /** Icon to be displayed inside the dropzone area. */
+    Icon: PropTypes.elementType,
     /** Currently loaded files. */
     fileObjects: PropTypes.arrayOf(FileObjectShape),
     /** Maximum file size (in bytes) that the dropzone will accept. */

--- a/src/components/DropzoneAreaBase.md
+++ b/src/components/DropzoneAreaBase.md
@@ -25,6 +25,19 @@ import { DropzoneAreaBase } from 'material-ui-dropzone';
 />
 ```
 
+### Custom Dropzone Icon
+
+```jsx
+import { AttachFile } from '@material-ui/icons';
+
+<DropzoneAreaBase
+  Icon={AttachFile}
+  dropzoneText={"Drag and drop an image here or click"}
+  onChange={(files) => console.log('Files:', files)}
+  onAlert={(message, variant) => console.log(`${variant}: ${message}`)}
+/>
+```
+
 ### Custom Preview Icon
 
 Demonstration of how to customize the preview icon for:

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -40,6 +40,7 @@ export type DropzoneAreaBaseProps = {
   acceptedFiles?: string[];
   fileObjects: FileObject[];
   filesLimit?: number;
+  Icon?: React.ReactElement;
   maxFileSize?: number;
   dropzoneText?: string;
   previewText?: string;


### PR DESCRIPTION
## Description

This PR adds a new `Icon` prop that allow passing a custom icon to be displayed inside the dropzone area.

- Fixes #48 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested

- [x] Interactive docs testing

**Test Configuration**:

- Browser: Edge 84

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
