### PR TITLE
Updating dialogTitle prop to be a string or element

### DIFF
--- a/src/components/DropzoneDialogBase.js
+++ b/src/components/DropzoneDialogBase.js
@@ -117,7 +117,10 @@ DropzoneDialogBase.propTypes = {
     /** Sets whether the dialog is open or closed. */
     open: PropTypes.bool,
     /** The Dialog title. */
-    dialogTitle: PropTypes.string,
+    dialogTitle: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.element,
+    ]),
     /**
      * Props to pass to the Material-UI Dialog components.
      * @see See [Material-UI Dialog](https://material-ui.com/api/dialog/#props) for available values.

--- a/src/components/DropzoneDialogBase.md
+++ b/src/components/DropzoneDialogBase.md
@@ -8,9 +8,22 @@ import { DropzoneDialogBase } from 'material-ui-dropzone';
 
 ```jsx
 import Button from '@material-ui/core/Button';
+import IconButton from '@material-ui/core/IconButton';
+import CloseIcon from '@material-ui/icons/Close';
 
 const [open, setOpen] = React.useState(false);
 const [fileObjects, setFileObjects] = React.useState([]);
+
+const dialogTitle = () => (
+  <>
+    <span>Upload file</span>
+    <IconButton
+      style={{right: '12px', top: '8px', position: 'absolute'}}
+      onClick={() => setOpen(false)}>
+      <CloseIcon />
+    </IconButton>
+  </>
+);
 
 <div>
   <Button variant="contained" color="primary" onClick={() => setOpen(true)}>
@@ -18,6 +31,7 @@ const [fileObjects, setFileObjects] = React.useState([]);
   </Button>
 
   <DropzoneDialogBase
+    dialogTitle={dialogTitle()}
     acceptedFiles={['image/*']}
     fileObjects={fileObjects}
     cancelButtonText={"cancel"}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -107,7 +107,7 @@ export const DropzoneArea: React.ComponentType<DropzoneAreaProps>;
 export type DropzoneDialogBaseProps = DropzoneAreaBaseProps & {
   cancelButtonText?: string;
   dialogProps?: DialogProps;
-  dialogTitle?: string;
+  dialogTitle?: string | JSX.Element;
   fullWidth?: boolean;
   maxWidth?: string;
   onClose?: (event: React.SyntheticEvent) => void;


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
* Adding the ability to customise the dialog title with JSX, rather than it just being a string.

<!--
Link related issues

- Fixes # (issue)
- Fixes # (issue)
-->

## Type of change

<!--
  Please delete options that are not relevant.
-->

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration
-->

- [ ] Adding to the documentation page for the `DropzoneDialogBase` an example that includes a custom dialog title with an 'x' button for closing the dialog.

**Test Configuration**:

- Browser: Chrome Version 84.0.4147.105

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
