### PR TITLE
🐛 Use binary system to convert bytes to kbs and mbs

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -6,11 +6,10 @@ export function isImage(file) {
 
 export function convertBytesToMbsOrKbs(filesize) {
     let size = '';
-    // I know, not technically correct...
-    if (filesize >= 1000000) {
-        size = (filesize / 1000000) + ' megabytes';
-    } else if (filesize >= 1000) {
-        size = (filesize / 1000) + ' kilobytes';
+    if (filesize >= 1048576) {
+        size = (filesize / 1048576) + ' megabytes';
+    } else if (filesize >= 1024) {
+        size = (filesize / 1024) + ' kilobytes';
     } else {
         size = filesize + ' bytes';
     }


### PR DESCRIPTION
## Description

`convertBytesToMbsOrKbs` was using the decimal system to convert bytes to megabytes and kilobytes. I switched to binary system to match the actual file's size verification.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- [x] Interactive docs testing

**Test Configuration**:

- Browser: Firefox 80.0.1

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
