### PR TITLE
🐛 Add disableRejectionFeedback to DropzoneAreaBaseProps type

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -66,6 +66,7 @@ export type DropzoneAreaBaseProps = {
   clearOnUnmount?: boolean;
   dropzoneClass?: string;
   dropzoneParagraphClass?: string;
+  disableRejectionFeedback?: boolean;
   onAdd?: (newFiles: FileObject[]) => void;
   onDelete?: (deletedFileObject: FileObject, index: number) => void;
   onDrop?: (files: File[], event: DropEvent) => void;


### PR DESCRIPTION
## Add disableRejectionFeedback to DropzoneAreaBaseProps type

disableRejectionFeedback doesn't currently exist in the DropzoneAreaBaseProps type. This causes an error when using Typescript. 


- Related to #141 


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- Tested by launching the interactive docs by running yarn docs:dev and setting the disableRejectionFeedback prop in DropzoneAreaBase components.

- Made sure yarn build works.

- Browser: Chrome Version 85.0.4183.102 (Official Build) (64-bit)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
