### PR TITLE
Fixes typings

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -40,7 +40,7 @@ export type DropzoneAreaBaseProps = {
   acceptedFiles?: string[];
   fileObjects: FileObject[];
   filesLimit?: number;
-  Icon?: React.ReactElement;
+  Icon?: React.ComponentType;
   maxFileSize?: number;
   dropzoneText?: string;
   previewText?: string;


### PR DESCRIPTION
## Description

Current implementation allows setting prop `Icon={<MyIcon />}` instead of `Icon={MyIcon}` causing the build to fail.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

```
import { DropzoneArea } from 'material-ui-dropzone';
import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
...
<DropzoneArea
      Icon={ArrowForwardIcon}  <-- Compile error
/>
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
