### PR TITLE
:bug: Pass deleted file index to onDelete in DropZoneArea

### DIFF
--- a/src/components/DropzoneArea.js
+++ b/src/components/DropzoneArea.js
@@ -110,7 +110,7 @@ class DropzoneArea extends React.PureComponent {
 
         // Notify removed file
         if (onDelete) {
-            onDelete(removedFileObj.file);
+            onDelete(removedFileObj.file, removedFileObjIdx);
         }
 
         // Update local state
@@ -165,6 +165,7 @@ DropzoneArea.propTypes = {
      * Fired when a file is deleted from the previews panel.
      *
      * @param {File} deletedFile The file that was removed.
+     * @param {number} index The index of the removed file object.
      */
     onDelete: PropTypes.func,
 };


### PR DESCRIPTION
Pass the index of the deleted file object to DropZoneArea's `onDelete` prop. 

I use this module in my project where I pass a list of URLs as `initialImages`. However, once the images are loaded to DropZoneArea, the original URL is no longer known. When an image passed as an initial image is deleted, the parent component which uses `DropZoneArea` cannot discern which image was deleted because of the lack of original URL or index of the deleted image passed to `onDelete` function.

This PR exposes the deleted file index to a parent component, so that a parent component can discern the exact image which was deleted.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration
-->

- [x] Test A: Pass an `onDelete` function which accepts the index as a 2nd parameter. By logging the 2nd parameter in `onDelete` function, it can be found out that it's correctly passed.

```js
const onDelete = (deletedFile, deletedFileIndex) => {
    console.log(deletedFileIndex)
}

<DropZoneArea 
    onDelete={onDelete} 
    // probably some other props
/>
```

**Test Configuration**:

- Browser: Google Chrome Version 87.0.4280.67 (Official Build) (x86_64)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
