### PR TITLE
Bugfix: previewGridClasses.image not being passed to <img>

### DIFF
--- a/src/components/DropzoneAreaBase.js
+++ b/src/components/DropzoneAreaBase.js
@@ -320,6 +320,8 @@ class DropzoneAreaBase extends React.PureComponent {
             </Fragment>
         );
     }
+                                  classes={classes}
+                          classes={classes}
 }
 
 DropzoneAreaBase.defaultProps = {

--- a/src/components/DropzoneAreaBase.js
+++ b/src/components/DropzoneAreaBase.js
@@ -65,10 +65,10 @@ const defaultSnackbarAnchorOrigin = {
     vertical: 'bottom',
 };
 
-const defaultGetPreviewIcon = (fileObject, classes) => {
+const defaultGetPreviewIcon = (fileObject, classes, previewGridClasses) => {
     if (isImage(fileObject.file)) {
         return (<img
-            className={classes.image}
+            className={classes.image + ' ' + previewGridClasses.image}
             role="presentation"
             src={fileObject.data}
         />);
@@ -276,6 +276,7 @@ class DropzoneAreaBase extends React.PureComponent {
                                     previewChipProps={previewChipProps}
                                     previewGridClasses={previewGridClasses}
                                     previewGridProps={previewGridProps}
+                                    classes={classes}
                                 />
                             }
                         </div>
@@ -297,6 +298,7 @@ class DropzoneAreaBase extends React.PureComponent {
                             previewChipProps={previewChipProps}
                             previewGridClasses={previewGridClasses}
                             previewGridProps={previewGridProps}
+                            classes={classes}
                         />
                     </Fragment>
                 }
@@ -320,8 +322,6 @@ class DropzoneAreaBase extends React.PureComponent {
             </Fragment>
         );
     }
-                                  classes={classes}
-                          classes={classes}
 }
 
 DropzoneAreaBase.defaultProps = {

--- a/src/components/PreviewList.js
+++ b/src/components/PreviewList.js
@@ -105,6 +105,7 @@ function PreviewList({
                         className={clsx(classes.imageContainer, previewGridClasses.item)}
                     >
                         {getPreviewIcon(fileObject, classes)}
+                        {getPreviewIcon(fileObject, classes, previewGridClasses)}
 
                         {showFileNames && (
                             <Typography variant="body1" component="p">

--- a/src/components/PreviewList.js
+++ b/src/components/PreviewList.js
@@ -104,7 +104,6 @@ function PreviewList({
                         key={`${fileObject.file?.name ?? 'file'}-${i}`}
                         className={clsx(classes.imageContainer, previewGridClasses.item)}
                     >
-                        {getPreviewIcon(fileObject, classes)}
                         {getPreviewIcon(fileObject, classes, previewGridClasses)}
 
                         {showFileNames && (


### PR DESCRIPTION
## Description

Fixed a bug when adding prop previewGridClasses={image: 'imageClass'} to <DropzoneArea>, the class didn't pass to the <img>.

Added a previewGridClasses prop to defaultGetPreviewIcon, so the classes.image and previewGridClasses.image are added together to the <img> className.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
