### PR TITLE
Modify previewChipProps type in DropzoneAreaBase and PreviewList

### DIFF
--- a/src/components/DropzoneAreaBase.js
+++ b/src/components/DropzoneAreaBase.js
@@ -405,7 +405,7 @@ DropzoneAreaBase.propTypes = {
      *
      * @see See [Material-UI Chip](https://material-ui.com/api/chip/#props) for available values.
      */
-    previewChipProps: PropTypes.object,
+    previewChipProps: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     /**
      * Custom CSS classNames for preview Grid components.<br/>
      * Should be in the form {container: string, item: string, image: string}.

--- a/src/components/PreviewList.js
+++ b/src/components/PreviewList.js
@@ -68,6 +68,10 @@ function PreviewList({
                 className={clsx(classes.root, previewGridClasses.container)}
             >
                 {fileObjects.map((fileObject, i) => {
+                    let chipProps = previewChipProps;
+                    if (typeof previewChipProps === 'function') {
+                        chipProps = previewChipProps(fileObject);
+                    }
                     return (
                         <Grid
                             {...previewGridProps.item}
@@ -77,7 +81,7 @@ function PreviewList({
                         >
                             <Chip
                                 variant="outlined"
-                                {...previewChipProps}
+                                {...chipProps}
                                 label={fileObject.file.name}
                                 onDelete={handleRemove(i)}
                             />
@@ -131,7 +135,7 @@ PreviewList.propTypes = {
     fileObjects: PropTypes.arrayOf(PropTypes.object).isRequired,
     getPreviewIcon: PropTypes.func.isRequired,
     handleRemove: PropTypes.func.isRequired,
-    previewChipProps: PropTypes.object,
+    previewChipProps: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
     previewGridClasses: PropTypes.object,
     previewGridProps: PropTypes.object,
     showFileNames: PropTypes.bool,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -49,7 +49,7 @@ export type DropzoneAreaBaseProps = {
   showFileNamesInPreview?: boolean;
   showFileNames?: boolean;
   useChipsForPreview?: boolean;
-  previewChipProps?: ChipProps;
+  previewChipProps?: ChipProps | ((fileObject: FileObject) => ChipProps);
   previewGridClasses?: {
     container?: string;
     item?: string;


### PR DESCRIPTION
## Description

Allow previewChipProps to accept a `func` that accepts a `FileObject` and returns `ChipProps`

Fulfills #290 

## Type of change

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested

In a react app

**Test Configuration**:

- Browser:

Firefox

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
