### PR TITLE
Update isImage helper with file signatures

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,7 +1,28 @@
 export function isImage(file) {
-    if (file.type.split('/')[0] === 'image') {
-        return true;
+    var reader = new FileReader();
+    reader.onloadend = (event) => {
+        var arr = (new Uint8Array(event.target.result)).subarray(0, 4);
+        var header = "";
+        for (var i = 0; i < arr.length; i++) {
+            header += arr[i].toString(16);
+        }
+
+        switch (header) {
+            case "47494638": // GIF
+            case "52494646": // WEBP
+            case "89504e47": // PNG
+            case "ffd8ffe0": // JPEG
+            case "ffd8ffe1": // JPEG
+            case "ffd8ffe2": // JPEG
+            case "ffd8ffe3": // JPEG
+            case "ffd8ffe8": // JPEG
+                return true;
+            default:
+                return false;
+        }
+
     }
+    fileReader.readAsArrayBuffer(file);
 }
 
 export function convertBytesToMbsOrKbs(filesize) {


### PR DESCRIPTION
## Description

The isImage helper function depends on the mime type and in certain cases it doesn't work as expected. See related issues.
To overcome this issues, using file signature inspection is proposed.

- Fixes #292 
- Fixes #313

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

- https://jsbin.com/gaxovoreha/edit?html,js,console,output

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules


I haven't worked with JS for a while and haven't had the time to properly test this PR. Anyone feel free to pick it up from here if needed.

