### PR TITLE
Change description of onDrop

### DIFF
--- a/src/components/DropzoneAreaBase.js
+++ b/src/components/DropzoneAreaBase.js
@@ -545,7 +545,7 @@ DropzoneAreaBase.propTypes = {
      */
     onDelete: PropTypes.func,
     /**
-     * Fired when the user drops files into the dropzone.
+     * Fired when the user drops files into the dropzone and the files are accepted.
      *
      * @param {File[]} droppedFiles All the files dropped into the dropzone.
      * @param {Event} event The react-dropzone drop event.

--- a/src/components/DropzoneAreaBase.js
+++ b/src/components/DropzoneAreaBase.js
@@ -547,7 +547,7 @@ DropzoneAreaBase.propTypes = {
     /**
      * Fired when the user drops files into the dropzone and the files are accepted.
      *
-     * @param {File[]} droppedFiles All the files dropped into the dropzone.
+     * @param {File[]} acceptedFiles All the accepted files dropped into the dropzone.
      * @param {Event} event The react-dropzone drop event.
      */
     onDrop: PropTypes.func,


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
Update the description of the `onDrop` prop in `DropzoneAreaBase`. 

Currently, the [docs](https://yuvaleros.github.io/material-ui-dropzone/) say that `onDrop` is fired whenever files are dropped onto the dropzone but it's slightly unclear whether `onDrop` is fired _only_ when the files are accepted, or when the files are accepted _or_ rejected. 

![image](https://user-images.githubusercontent.com/32407086/180790293-3a61f68b-6095-4a0a-818a-e40bf4b39244.png)

If we look at the relevant code [here](https://github.com/Yuvaleros/material-ui-dropzone/blob/8f0be37c5d77012d6ec6cf9d84f4a9e1cc638d77/src/components/DropzoneAreaBase.js#L103-L118) **we see that `onDrop` is fired only when files are accepted**.

I wanted to make this change because if we look at the props for [Dropzone](https://react-dropzone.js.org/#src) in the react-dropzone library, `onDrop` is fired when the files are either rejected _or_ accepted:

![image](https://user-images.githubusercontent.com/32407086/180789525-1d386883-a489-4258-bf49-86c0c32e6dad.png)

Thus, I thought a user might incorrectly assume DropzoneAreaBase's `onDrop` to behave similarly to Dropzone's `onDrop` and expect it to return all dropped files, whether rejected or accepted. 

Ideally, I would've liked to rename the `onDrop` prop to `onDropAccepted` but that would be a breaking change so I thought updating the docs would suffice. Thank you!




<!--
Link related issues

- Fixes # (issue)
- Fixes # (issue)
-->

## Type of change

<!--
  Please delete options that are not relevant.
-->

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration
-->

- [x] Tested updated docs locally

**Test Configuration**:

- Browser:

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
