### PR TITLE
Let user access dropped files when file limit is exceeded

### DIFF
--- a/src/components/DropzoneAreaBase.js
+++ b/src/components/DropzoneAreaBase.js
@@ -101,7 +101,7 @@ class DropzoneAreaBase extends React.PureComponent {
     }
 
     handleDropAccepted = async(acceptedFiles, evt) => {
-        const {fileObjects, filesLimit, getFileAddedMessage, getFileLimitExceedMessage, onAdd, onDrop} = this.props;
+        const {fileObjects, filesLimit, getFileAddedMessage, getFileLimitExceedMessage, onAdd, onDrop, onFilesLimitExceeded} = this.props;
 
         if (filesLimit > 1 && fileObjects.length + acceptedFiles.length > filesLimit) {
             this.setState({
@@ -109,6 +109,7 @@ class DropzoneAreaBase extends React.PureComponent {
                 snackbarMessage: getFileLimitExceedMessage(filesLimit),
                 snackbarVariant: 'error',
             }, this.notifyAlert);
+            onFilesLimitExceeded(acceptedFiles, evt);
             return;
         }
 
@@ -558,6 +559,13 @@ DropzoneAreaBase.propTypes = {
      * @param {Event} event The react-dropzone drop event.
      */
     onDropRejected: PropTypes.func,
+    /**
+     * Fired when dropped files causes the total file count to exceed the filesLimit.
+     *
+     * @param {File[]} rejectedFiles All the dropped files.
+     * @param {Event} event The react-dropzone drop event.
+     */
+    onFilesLimitExceeded: PropTypes.func,
     /**
      * Fired when an alert is triggered.
      *


### PR DESCRIPTION
## Description

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->
Currently, if files are dropped and the total file count exceeds the `filesLimit`, the dropped files that cause the `filesLimit` to be exceeded are not accessible by the user through any prop. If we look at the relevant code [here](https://github.com/Yuvaleros/material-ui-dropzone/blob/8f0be37c5d77012d6ec6cf9d84f4a9e1cc638d77/src/components/DropzoneAreaBase.js#L103-L113), we see that we terminate the 
function without passing the files to any prop handler like `onDrop`

![image](https://user-images.githubusercontent.com/32407086/180834305-3852d206-56d2-4d1f-aa1a-845ec7752f46.png)


I added a new prop that lets the user access the files that cause the `filesLimit` to be exceeded. Files that are rejected on drop are accessible using the `onDropRejected` prop - however, `onDropRejected` does not return dropped files that cause the `filesLimit` to be exceeded because these files are _not rejected by [react-dropzone](https://react-dropzone.js.org/#src) but instead accepted_.

[Codesandbox link to demonstrate the bug](https://codesandbox.io/s/material-ui-dropzoneareabase-4zl0bn?file=/src/App.js)
<!--
Link related issues

- Fixes # (issue)
- Fixes # (issue)
-->

## Type of change

<!--
  Please delete options that are not relevant.
-->

- New feature (non-breaking change which adds functionality)

## How Has This Been Tested

<!--
  Please describe the tests that you ran to verify your changes.
  Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration
-->

- [x] Generated a build of my fork and tested it locally

**Test Configuration**:

- Browser:

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
